### PR TITLE
sources.rs: fix test_get_download_url

### DIFF
--- a/rye/src/sources.rs
+++ b/rye/src/sources.rs
@@ -120,9 +120,9 @@ pub fn get_download_url(
 #[test]
 fn test_get_download_url() {
     let url = get_download_url("3.8.14", "macos", "aarch64");
-    assert_eq!(url, Some((PythonVersion { kind: "cpython", major: 3, minor: 8, patch: 14 }, "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-aarch64-apple-darwin-debug-full.tar.zst")));
+    assert_eq!(url, Some((PythonVersion { kind: "cpython", major: 3, minor: 8, patch: 14 }, "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-aarch64-apple-darwin-pgo-full.tar.zst")));
     let url = get_download_url("3.8", "macos", "aarch64");
-    assert_eq!(url, Some((PythonVersion { kind: "cpython", major: 3, minor: 8, patch: 16 }, "https://github.com/indygreg/python-build-standalone/releases/download/20221220/cpython-3.8.16%2B20221220-aarch64-apple-darwin-debug-full.tar.zst")));
+    assert_eq!(url, Some((PythonVersion { kind: "cpython", major: 3, minor: 8, patch: 16 }, "https://github.com/indygreg/python-build-standalone/releases/download/20221220/cpython-3.8.16%2B20221220-aarch64-apple-darwin-pgo-full.tar.zst")));
     let url = get_download_url("3", "macos", "aarch64");
-    assert_eq!(url, Some((PythonVersion { kind: "cpython", major: 3, minor: 11, patch: 1}, "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-aarch64-apple-darwin-debug-full.tar.zst")));
+    assert_eq!(url, Some((PythonVersion { kind: "cpython", major: 3, minor: 11, patch: 1}, "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-aarch64-apple-darwin-pgo-full.tar.zst")));
 }


### PR DESCRIPTION
From my testing, the `test_get_download_url` fails with:
```
     Running unittests src/main.rs (target/x86_64-unknown-linux-gnu/release/deps/rye-f2fb693ac01ef08b)

running 1 test
test sources::test_get_download_url ... FAILED

failures:

---- sources::test_get_download_url stdout ----
thread 'sources::test_get_download_url' panicked at 'assertion failed: `(left == right)`
  left: `Some((PythonVersion { kind: "cpython", major: 3, minor: 8, patch: 14 }, "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-aarch64-apple-darwin-pgo-full.tar.zst"))`,
 right: `Some((PythonVersion { kind: "cpython", major: 3, minor: 8, patch: 14 }, "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-aarch64-apple-darwin-debug-full.tar.zst"))`', rye/src/sources.rs:123:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    sources::test_get_download_url

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

This PR changes the expected value for the URLs and hence fixes those tests.
I am not sure rather this is correct though.