### PR TITLE
Update GitHub Actions CI

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -7,12 +7,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          profile: minimal
           components: clippy, rustfmt
-          override: true
       - name: Run clippy
         run: make lint

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -7,12 +7,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          profile: minimal
           components: clippy, rustfmt
-          override: true
       - name: Run rustfmt
         run: make format-check

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,12 +8,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          profile: minimal
-          override: true
       - name: Check
         run: make check
       - name: Test


### PR DESCRIPTION
The following updates are performed:
* update [`actions/checkout`](https://github.com/actions/checkout) to v3
* replace [unmaintained](https://github.com/actions-rs/toolchain/issues/216) `actions-rs/toolchain` by [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain)

Still using the outdated / unmaintained actions will generate several warnings in CI runs, for example in https://github.com/mitsuhiko/rye/actions/runs/4780552270:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions-rs/toolchain@v1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

The PR will get rid of those warnings.