### PR TITLE
Update pyproject.toml with new pinned Python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ most recent changes however.
 
 ## April
 
+- Rye's `pin` command now updates the pyproject.toml requires-python.
+
 - Rye's `install` command now accepts a `--include-dep` parameter to include
   scripts from one or more given dependencies.
 

--- a/rye/src/cli/pin.rs
+++ b/rye/src/cli/pin.rs
@@ -10,10 +10,18 @@ use crate::pyproject::PyProject;
 use crate::sources::PythonVersionRequest;
 
 /// Pins a Python version to this project.
+///
+/// This will update the `.python-version` to point to the provided version.
+/// Additionally it will update `requires-python` in the `pyproject.toml`
+/// if it's lower than the current version.  This can be disabled by passing
+/// `--no-update-requires-python`.
 #[derive(Parser, Debug)]
 pub struct Args {
     /// The version of Python to pin.
     version: String,
+    /// Prevent updating requires-python in the pyproject.toml.
+    #[arg(long)]
+    no_update_requires_python: bool,
 }
 
 pub fn execute(cmd: Args) -> Result<(), Error> {
@@ -28,12 +36,15 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
     fs::write(&version_file, format!("{}\n", to_write))
         .context("failed to write .python-version file")?;
 
-    let mut pyproject_toml = PyProject::discover()?;
-    let new_version = to_write.parse::<PythonVersionRequest>()?;
-    if let Some(curr_version) = pyproject_toml.target_python_version() {
-        if new_version < curr_version {
-            pyproject_toml.set_target_python_version(&new_version);
-            pyproject_toml.save()?;
+    if !cmd.no_update_requires_python {
+        if let Ok(mut pyproject_toml) = PyProject::discover() {
+            let new_version = to_write.parse::<PythonVersionRequest>()?;
+            if let Some(curr_version) = pyproject_toml.target_python_version() {
+                if new_version < curr_version {
+                    pyproject_toml.set_target_python_version(&new_version);
+                    pyproject_toml.save()?;
+                }
+            }
         }
     }
 

--- a/rye/src/cli/pin.rs
+++ b/rye/src/cli/pin.rs
@@ -28,6 +28,15 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
     fs::write(&version_file, format!("{}\n", to_write))
         .context("failed to write .python-version file")?;
 
+    let mut pyproject_toml = PyProject::discover()?;
+    let new_version = to_write.parse::<PythonVersionRequest>()?;
+    if let Some(curr_version) = pyproject_toml.target_python_version() {
+        if new_version < curr_version {
+            pyproject_toml.set_target_python_version(&new_version);
+            pyproject_toml.save()?;
+        }
+    }
+
     eprintln!("pinned {} in {}", to_write, version_file.display());
 
     Ok(())

--- a/rye/src/pyproject.rs
+++ b/rye/src/pyproject.rs
@@ -15,7 +15,7 @@ use once_cell::sync::Lazy;
 use pep440_rs::{Operator, VersionSpecifiers};
 use pep508_rs::Requirement;
 use regex::Regex;
-use toml_edit::{Array, Document, Item, Table, TableLike, Value};
+use toml_edit::{Array, Document, Formatted, Item, Table, TableLike, Value};
 
 use crate::config::load_python_version;
 use crate::sources::{PythonVersion, PythonVersionRequest};
@@ -393,6 +393,21 @@ impl PyProject {
         }
 
         None
+    }
+
+    /// Set the target Python version.
+    pub fn set_target_python_version(&mut self, version: &PythonVersionRequest) {
+        let mut marker = format!(">= {}", version.major);
+        if let Some(minor) = version.minor {
+            marker.push('.');
+            marker.push_str(&minor.to_string());
+        }
+
+        let project = self
+            .doc
+            .entry("project")
+            .or_insert(Item::Table(Table::new()));
+        project["requires-python"] = Item::Value(Value::String(Formatted::new(marker)));
     }
 
     /// Returns the project name.


### PR DESCRIPTION
Closes #74

This PR currently updates requires-python in pyproject.toml if the version pinned is older than the marked requires-python version.

```zsh
❯ rye pin 3.11      # doesn't change anything in a ">= 3.10" marked project
❯ rye pin 3.8       # updates the requires-python in the toml to ">= 3.8" 
```

________
**Alternatively** we could provide the following [experience](https://github.com/mitsuhiko/rye/pull/75#issuecomment-1529034966):
```zsh
❯ rye pin 3.11      # doesn't change anything in a ">= 10" marked project
❯ rye pin 3.8       # fails similar to pip install <packages> in a ">= 3.10" marked project
❯ rye pin 3.8 -f    # updates the requires-python in the toml to ">= 3.8"
```

I can add [those changes](https://github.com/cnpryer/rye/compare/pin-requires-python...cnpryer:rye:pin-requires-python-2) to this PR if you'd like.