### PR TITLE
Add help message for init --license

### DIFF
--- a/rye/src/cli/init.rs
+++ b/rye/src/cli/init.rs
@@ -35,6 +35,7 @@ pub struct Args {
     /// Which build system should be used?
     #[arg(long, default_value = "hatchling")]
     build_system: BuildSystem,
+    /// Which license should be used(SPDX identifier)?
     #[arg(long)]
     license: Option<String>,
 }

--- a/rye/src/cli/init.rs
+++ b/rye/src/cli/init.rs
@@ -35,7 +35,7 @@ pub struct Args {
     /// Which build system should be used?
     #[arg(long, default_value = "hatchling")]
     build_system: BuildSystem,
-    /// Which license should be used(SPDX identifier)?
+    /// Which license should be used (SPDX identifier)?
     #[arg(long)]
     license: Option<String>,
 }


### PR DESCRIPTION
I noticed that `--license` was missing a help message description, so I added one.