### PR TITLE
More consistent python version handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ most recent changes however.
 
 ## May
 
+- Rye now has a most consistent handling for virtualenv versions.  If
+  `.python-version` is provided, that version is used.  Otherwise if
+  `requires-python` is set in the `pyproject.toml`, that version is used
+  instead.  When a new project is created the `.python-version` file is
+  written and the current latest cpython version is picked.
+
 - Rye's `init` command now attempts to initialize projects with `git` and
   will automatically create a `src/project_name/__init__.py` file.
 

--- a/rye/src/cli/init.rs
+++ b/rye/src/cli/init.rs
@@ -9,7 +9,9 @@ use license::License;
 use minijinja::{context, Environment};
 use serde::Serialize;
 
-use crate::config::{get_default_author, load_python_version};
+use crate::config::{get_default_author, get_latest_cpython, get_python_version_from_pyenv_pin};
+
+const DEFAULT_LOWER_BOUND_PYTHON: &str = "3.8";
 
 #[derive(ValueEnum, Copy, Clone, Serialize, Debug)]
 #[value(rename_all = "snake_case")]
@@ -26,7 +28,10 @@ pub struct Args {
     /// Where to place the project (defaults to current path)
     #[arg(default_value = ".")]
     path: PathBuf,
-    /// Which interpreter version should be used?
+    /// Minimal Python version supported by this project.
+    #[arg(long)]
+    min_py: Option<String>,
+    /// Python version to use for the virtualenv.
     #[arg(short, long)]
     py: Option<String>,
     /// Do not create a readme.
@@ -118,6 +123,7 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
     let toml = dir.join("pyproject.toml");
     let readme = dir.join("README.md");
     let license_file = dir.join("LICENSE.txt");
+    let python_version_file = dir.join(".python-version");
 
     if toml.is_file() {
         bail!("pyproject.toml already exists");
@@ -127,15 +133,25 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
     fs::create_dir_all(&dir).ok();
 
     // Write pyproject.toml
+    let min_py = match cmd.min_py {
+        Some(py) => py,
+        None => get_python_version_from_pyenv_pin()
+            .map(|x| format!("{}.{}", x.major, x.minor))
+            .unwrap_or_else(|| DEFAULT_LOWER_BOUND_PYTHON.into()),
+    };
     let py = match cmd.py {
         Some(py) => py,
-        None => load_python_version()
-            .map(|x| format!("{}.{}", x.major, x.minor))
-            .unwrap_or_else(|| "3.8".into()),
+        None => {
+            let version = get_python_version_from_pyenv_pin()
+                .map(Ok)
+                .unwrap_or_else(get_latest_cpython)?;
+            format!("{}.{}.{}", version.major, version.minor, version.patch)
+        }
     };
+
     let name = slug::slugify(dir.file_name().unwrap().to_string_lossy());
     let version = "0.1.0";
-    let requires_python = format!(">= {}", py);
+    let requires_python = format!(">= {}", min_py);
     let author = get_default_author();
     let license = if let Some(license) = cmd.license {
         if !license_file.is_file() {
@@ -156,6 +172,12 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
     } else {
         None
     };
+
+    // write .python-version
+    if !python_version_file.is_file() {
+        fs::write(python_version_file, format!("{}\n", py))
+            .context("could not write .python-version file")?;
+    }
 
     // create a readme if one is missing
     let with_readme = if readme.is_file() {

--- a/rye/src/cli/show.rs
+++ b/rye/src/cli/show.rs
@@ -6,8 +6,7 @@ use clap::Parser;
 use console::style;
 
 use crate::bootstrap::ensure_self_venv;
-use crate::config::load_python_version;
-use crate::pyproject::PyProject;
+use crate::pyproject::{get_current_venv_python_version, PyProject};
 use crate::utils::CommandOutput;
 
 /// Prints the current state of the project.
@@ -32,10 +31,15 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
     println!("path: {}", style(project.root_path().display()).cyan());
     println!("venv: {}", style(project.venv_path().display()).cyan());
     if let Some(ver) = project.target_python_version() {
-        println!("min python: {}", style(ver).cyan());
+        println!("target python: {}", style(ver).cyan());
     }
-    if let Some(ver) = load_python_version() {
-        println!("pinned python: {}", style(ver).cyan());
+    if let Ok(ver) = project.venv_python_version() {
+        println!("venv python: {}", style(&ver).cyan());
+        if let Some(actual) = get_current_venv_python_version(&project.venv_path()) {
+            if actual != ver {
+                println!("last synched venv python: {}", style(&actual).red());
+            }
+        }
     }
 
     if let Some(workspace) = project.workspace() {

--- a/rye/src/config.rs
+++ b/rye/src/config.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::{env, fs};
 
-use anyhow::{anyhow, Error};
+use anyhow::{anyhow, Context, Error};
 use once_cell::sync::Lazy;
 
 use crate::sources::{get_download_url, PythonVersion, PythonVersionRequest};
@@ -122,7 +122,7 @@ pub fn get_default_author() -> Option<(String, String)> {
 }
 
 /// Reads the current `.python-version` file.
-pub fn load_python_version() -> Option<PythonVersion> {
+pub fn get_python_version_from_pyenv_pin() -> Option<PythonVersion> {
     let mut here = env::current_dir().ok()?;
 
     loop {
@@ -138,4 +138,21 @@ pub fn load_python_version() -> Option<PythonVersion> {
     }
 
     None
+}
+
+/// Returns the most recent cpython release.
+pub fn get_latest_cpython() -> Result<PythonVersion, Error> {
+    get_download_url(
+        &PythonVersionRequest {
+            kind: None,
+            major: 3,
+            minor: None,
+            patch: None,
+            suffix: None,
+        },
+        OS,
+        ARCH,
+    )
+    .map(|x| x.0)
+    .context("unsupported platform")
 }

--- a/rye/src/pyproject.rs
+++ b/rye/src/pyproject.rs
@@ -2,6 +2,7 @@ use core::fmt;
 use std::borrow::Cow;
 use std::collections::HashSet;
 use std::env;
+use std::env::consts::{ARCH, OS};
 use std::ffi::OsStr;
 use std::fs;
 use std::os::unix::prelude::MetadataExt;
@@ -15,10 +16,10 @@ use once_cell::sync::Lazy;
 use pep440_rs::{Operator, VersionSpecifiers};
 use pep508_rs::Requirement;
 use regex::Regex;
-use toml_edit::{Array, Document, Formatted, Item, Table, TableLike, Value};
+use toml_edit::{Array, Document, Formatted, Item, Table, Value};
 
-use crate::config::load_python_version;
-use crate::sources::{PythonVersion, PythonVersionRequest};
+use crate::config::get_python_version_from_pyenv_pin;
+use crate::sources::{get_download_url, PythonVersion, PythonVersionRequest};
 use crate::sync::VenvMarker;
 use crate::utils::{expand_env_vars, format_requirement};
 
@@ -100,24 +101,30 @@ impl fmt::Display for Script {
 #[derive(Debug)]
 pub struct Workspace {
     root: PathBuf,
+    doc: Document,
     members: Vec<String>,
 }
 
 impl Workspace {
     /// Loads a workspace from a pyproject.toml and path
-    pub fn from_workspace_section_and_path(workspace: &dyn TableLike, path: &Path) -> Workspace {
-        Workspace {
-            root: path.to_path_buf(),
-            members: workspace
-                .get("members")
-                .and_then(|x| x.as_array())
-                .map(|x| {
-                    x.iter()
-                        .filter_map(|item| item.as_str().map(|x| x.to_string()))
-                        .collect::<Vec<_>>()
-                })
-                .unwrap_or_default(),
-        }
+    fn try_load_from_toml(doc: &Document, path: &Path) -> Option<Workspace> {
+        doc.get("tool")
+            .and_then(|x| x.get("rye"))
+            .and_then(|x| x.get("workspace"))
+            .and_then(|x| x.as_table_like())
+            .map(|workspace| Workspace {
+                root: path.to_path_buf(),
+                doc: doc.clone(),
+                members: workspace
+                    .get("members")
+                    .and_then(|x| x.as_array())
+                    .map(|x| {
+                        x.iter()
+                            .filter_map(|item| item.as_str().map(|x| x.to_string()))
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default(),
+            })
     }
 
     /// Discovers a pyproject toml
@@ -212,17 +219,24 @@ impl Workspace {
         Ok(None)
     }
 
-    fn try_load_from_toml(doc: &Document, path: &Path) -> Option<Workspace> {
-        doc.get("tool")
-            .and_then(|x| x.get("rye"))
-            .and_then(|x| x.get("workspace"))
-            .and_then(|x| x.as_table_like())
-            .map(|workspace| Workspace::from_workspace_section_and_path(workspace, path))
-    }
-
     /// Returns the virtualenv path of the workspace.
     pub fn venv_path(&self) -> Cow<'_, Path> {
         Cow::Owned(self.root.join(".venv"))
+    }
+
+    /// Returns the project's target python version.
+    ///
+    /// That is the Python version that appears as lower bound in the
+    /// pyproject toml.
+    pub fn target_python_version(&self) -> Option<PythonVersionRequest> {
+        resolve_target_python_version(&self.doc, &self.venv_path())
+    }
+
+    /// Returns the project's intended venv python version.
+    ///
+    /// This is the python version that should be used for virtualenvs.
+    pub fn venv_python_version(&self) -> Result<PythonVersion, Error> {
+        resolve_intended_venv_python_version(&self.doc)
     }
 }
 
@@ -345,68 +359,24 @@ impl PyProject {
         Cow::Owned(self.venv_path().join("bin"))
     }
 
-    /// Reads the venv python version marker.
-    pub fn venv_python_version(&self) -> Option<PythonVersion> {
-        let marker_file = self.venv_path().join("rye-venv.json");
-        let contents = fs::read(marker_file).ok()?;
-        let marker: VenvMarker = serde_json::from_slice(&contents).ok()?;
-        Some(marker.python)
-    }
-
     /// Returns the project's target python version
     pub fn target_python_version(&self) -> Option<PythonVersionRequest> {
-        // TODO: make this workspace aware
-
-        // if there is a lower bound defined in requires-python, we go
-        // with that.
-        let lower_bound = self
-            .doc
-            .get("project")
-            .and_then(|x| x.get("requires-python"))
-            .and_then(|x| x.as_str())
-            .and_then(|s| s.parse::<VersionSpecifiers>().ok())
-            .and_then(|versions| {
-                versions
-                    .iter()
-                    .filter(|x| {
-                        matches!(
-                            x.operator(),
-                            Operator::Equal
-                                | Operator::EqualStar
-                                | Operator::GreaterThanEqual
-                                | Operator::GreaterThan
-                        )
-                    })
-                    .map(|x| {
-                        let mut rv = PythonVersionRequest::from(x.version().clone());
-                        // this is pretty shitty, but probably good enough
-                        if matches!(x.operator(), Operator::GreaterThan) {
-                            if let Some(ref mut patch) = rv.patch {
-                                *patch += 1;
-                            } else if let Some(ref mut minor) = rv.minor {
-                                *minor += 1;
-                            }
-                        }
-                        rv
-                    })
-                    .min()
-            });
-
-        if let Some(lower_bound) = lower_bound {
-            return Some(lower_bound);
+        if let Some(workspace) = self.workspace() {
+            workspace.target_python_version()
+        } else {
+            resolve_target_python_version(&self.doc, &self.venv_path())
         }
+    }
 
-        // otherwise let's check if we have a version in the virtualenv
-        if let Some(marker_python) = self.venv_python_version() {
-            return Some(marker_python.into());
+    /// Returns the project's intended venv python version.
+    ///
+    /// This is the python version that should be used for virtualenvs.
+    pub fn venv_python_version(&self) -> Result<PythonVersion, Error> {
+        if let Some(workspace) = self.workspace() {
+            workspace.venv_python_version()
+        } else {
+            resolve_intended_venv_python_version(&self.doc)
         }
-
-        // if nothing else works, pick up the .python-version file
-        if let Some(pyenv_python) = load_python_version() {
-            return Some(pyenv_python.into());
-        }
-
-        None
     }
 
     /// Set the target Python version.
@@ -648,6 +618,76 @@ fn remove_dependency(deps: &mut Array, req: &Requirement) -> Option<Requirement>
     } else {
         None
     }
+}
+
+pub fn get_current_venv_python_version(venv_path: &Path) -> Option<PythonVersion> {
+    let marker_file = venv_path.join("rye-venv.json");
+    let contents = fs::read(marker_file).ok()?;
+    let marker: VenvMarker = serde_json::from_slice(&contents).ok()?;
+    Some(marker.python)
+}
+
+fn resolve_target_python_version(doc: &Document, venv_path: &Path) -> Option<PythonVersionRequest> {
+    resolve_lower_bound_python_version(doc)
+        .or_else(|| get_current_venv_python_version(venv_path).map(Into::into))
+        .or_else(|| get_python_version_from_pyenv_pin().map(Into::into))
+}
+
+fn resolve_intended_venv_python_version(doc: &Document) -> Result<PythonVersion, Error> {
+    if let Some(ver) = get_python_version_from_pyenv_pin() {
+        return Ok(ver);
+    }
+    let requested_version = resolve_lower_bound_python_version(doc).ok_or_else(|| {
+        anyhow!(
+            "could not determine a target python version.  Define requires-python in \
+                 pyproject.toml or use a .python-version file"
+        )
+    })?;
+
+    if let Ok(ver) = PythonVersion::try_from(requested_version.clone()) {
+        return Ok(ver);
+    }
+
+    if let Some((latest, _)) = get_download_url(&requested_version, OS, ARCH) {
+        Ok(latest)
+    } else {
+        Err(anyhow!(
+            "Unable to determine target virtualenv python version"
+        ))
+    }
+}
+
+fn resolve_lower_bound_python_version(doc: &Document) -> Option<PythonVersionRequest> {
+    doc.get("project")
+        .and_then(|x| x.get("requires-python"))
+        .and_then(|x| x.as_str())
+        .and_then(|s| s.parse::<VersionSpecifiers>().ok())
+        .and_then(|versions| {
+            versions
+                .iter()
+                .filter(|x| {
+                    matches!(
+                        x.operator(),
+                        Operator::Equal
+                            | Operator::EqualStar
+                            | Operator::GreaterThanEqual
+                            | Operator::GreaterThan
+                    )
+                })
+                .map(|x| {
+                    let mut rv = PythonVersionRequest::from(x.version().clone());
+                    // this is pretty shitty, but probably good enough
+                    if matches!(x.operator(), Operator::GreaterThan) {
+                        if let Some(ref mut patch) = rv.patch {
+                            *patch += 1;
+                        } else if let Some(ref mut minor) = rv.minor {
+                            *minor += 1;
+                        }
+                    }
+                    rv
+                })
+                .min()
+        })
 }
 
 pub fn find_project_root() -> Option<PathBuf> {

--- a/rye/src/sources.rs
+++ b/rye/src/sources.rs
@@ -1,5 +1,4 @@
 use std::borrow::Cow;
-use std::env::consts::{ARCH, OS};
 use std::fmt;
 use std::str::FromStr;
 
@@ -22,25 +21,6 @@ pub struct PythonVersion {
     pub minor: u8,
     pub patch: u8,
     pub suffix: Option<Cow<'static, str>>,
-}
-
-impl PythonVersion {
-    /// Returns the latest version for this OS.
-    pub fn latest_cpython() -> PythonVersion {
-        get_download_url(
-            &PythonVersionRequest {
-                kind: None,
-                major: 3,
-                minor: None,
-                patch: None,
-                suffix: None,
-            },
-            OS,
-            ARCH,
-        )
-        .expect("unsupported platform")
-        .0
-    }
 }
 
 impl Serialize for PythonVersion {


### PR DESCRIPTION
This makes Rye more consistently work with Python versions. Before when a new venv was created, the latest cpython version was used in all cases and 3.8 was set as lower bound in the `pyproject.toml`.

Now the following logic applies:

* When creating a new project, `.python-version` is written and points to the latest cpython version. The `requires-python` key is set to `3.8` by default.
* When a virtualenv is created, `.python-version` is preferred, otherwise it falls back to `requires-python`.

This now also means that `.python-version` is entirely optional if you want to keep them in sync.

Refs #96