### PR TITLE
Auto install completion script to shell with --install flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ is the one you can install as mainline should always be stable.  Here are the
 most recent changes however.
 
 ## May
+- Added `--install` for `rye self completion` to install the completion script
+  directly into the shell's configuration.
 
 - Rye now includes a `publish` command for publishing Python packages to a
   package repository.  #86


### PR DESCRIPTION
@cnpryer helped add a script generation for shell completion https://github.com/mitsuhiko/rye/pull/97, it would be nice to add the script to the shell config file automatically.

Currently, only bash, zsh and fish are supported.

![2023-05-12 21 54 47](https://github.com/mitsuhiko/rye/assets/12986082/860daccb-7464-4a42-ac2b-3635c2f97bde)

