### PR TITLE
Added support for script chaining and env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ most recent changes however.
 
 ## May
 
+- Script declarations in `pyproject.toml` now permit chaining and custom
+  environment variables.  #153
+
 - Added `tools install` and `tools uninstall` as aliases for `install` and
   `uninstall` and added `tools list` to show all installed tools.
 

--- a/rye/src/cli/run.rs
+++ b/rye/src/cli/run.rs
@@ -1,14 +1,14 @@
 use std::env::{self, join_paths, split_paths};
 use std::ffi::OsString;
-use std::process::Command;
+use std::process::{Command, ExitStatus};
 
-use anyhow::{Context, Error};
+use anyhow::{bail, Context, Error};
 use clap::Parser;
 use console::style;
 
 use crate::pyproject::{PyProject, Script};
 use crate::sync::{sync, SyncOptions};
-use crate::utils::exec_spawn;
+use crate::utils::{exec_spawn, success_status};
 
 /// Runs a command installed into this package.
 #[derive(Parser, Debug)]
@@ -33,17 +33,25 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
 
     // make sure we have the minimal virtualenv.
     sync(SyncOptions::python_only()).context("failed to sync ahead of run")?;
-    let venv_bin = pyproject.venv_bin_path();
 
     if cmd.list || cmd.cmd.is_none() {
         return list_scripts(&pyproject);
     }
-    let mut args = match cmd.cmd {
+    let args = match cmd.cmd {
         Some(Cmd::External(args)) => args,
         None => unreachable!(),
     };
 
-    // do we have a custom script to invoke?
+    invoke_script(&pyproject, args, true)?;
+    unreachable!();
+}
+
+fn invoke_script(
+    pyproject: &PyProject,
+    mut args: Vec<OsString>,
+    exec: bool,
+) -> Result<ExitStatus, Error> {
+    let venv_bin = pyproject.venv_bin_path();
     match pyproject.get_script_cmd(&args[0].to_string_lossy()) {
         Some(Script::Cmd(script_args)) if !script_args.is_empty() => {
             let script_target = venv_bin.join(&script_args[0]);
@@ -64,26 +72,49 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
         Some(Script::External(_)) => {
             args[0] = venv_bin.join(&args[0]).into();
         }
-        _ => {}
+        Some(Script::Chain(commands)) => {
+            if args.len() != 1 {
+                bail!("extra arguments to chained commands are not allowed");
+            }
+            for args in commands {
+                let status =
+                    invoke_script(pyproject, args.into_iter().map(Into::into).collect(), false)?;
+                if !status.success() {
+                    if !exec {
+                        return Ok(status);
+                    } else {
+                        bail!("script failed with {}", status);
+                    }
+                }
+            }
+            if exec {
+                std::process::exit(0);
+            }
+            return Ok(success_status());
+        }
+        None | Some(Script::Cmd(_)) => {
+            bail!("invalid or unknown script '{}'", args[0].to_string_lossy());
+        }
     }
 
     let mut cmd = Command::new(&args[0]);
     cmd.args(&args[1..]);
-
-    // when we spawn into a script, we implicitly activate the virtualenv to make
-    // the life of tools easier that expect to be in one.
-    env::set_var("VIRTUAL_ENV", &*pyproject.venv_path());
+    cmd.env("VIRTUAL_ENV", &*pyproject.venv_path());
     if let Some(path) = env::var_os("PATH") {
         let mut paths = split_paths(&path).collect::<Vec<_>>();
         paths.insert(0, venv_bin.into());
         let new_path = join_paths(paths)?;
-        env::set_var("PATH", new_path);
+        cmd.env("PATH", new_path);
     } else {
-        env::set_var("PATH", &*venv_bin);
+        cmd.env("PATH", &*venv_bin);
     }
-    env::remove_var("PYTHONHOME");
+    cmd.env_remove("PYTHONHOME");
 
-    match exec_spawn(&mut cmd)? {};
+    if exec {
+        match exec_spawn(&mut cmd)? {};
+    } else {
+        Ok(cmd.status()?)
+    }
 }
 
 fn list_scripts(pyproject: &PyProject) -> Result<(), Error> {

--- a/rye/src/utils.rs
+++ b/rye/src/utils.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 use std::convert::Infallible;
 use std::io::{Cursor, Read};
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::{Command, ExitStatus, Stdio};
 use std::{fmt, fs};
 
 use anyhow::{anyhow, Error};
@@ -304,6 +304,20 @@ pub fn is_inside_git_work_tree(dir: &PathBuf) -> bool {
         .status()
         .map(|status| status.success())
         .unwrap_or(false)
+}
+
+/// Returns a success exit status.
+pub fn success_status() -> ExitStatus {
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::ExitStatusExt;
+        ExitStatus::from_raw(0)
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+        ExitStatus::from_raw(0)
+    }
 }
 
 #[test]


### PR DESCRIPTION
This adds support for script chaining and environment variables like so:

```toml
[tool.rye.scripts]
serve = { cmd = "flask run", env = {"FLASK_APP" = "./hello.py"} }
lint = { chain = ["lint:black", "lint:flake8" ] }
"lint:black" = "black --check src"
"lint:flake8" = "flake8 src"
```

With this you can run `rye run lint` to invoke first `rye run lint:black` followed by `rye run lint:flake8` if the first script did not fail. This really needs docs.

Output in list:

```
lint (chain: [lint:black], [lint:flake8])
lint:black (black --check src)
lint:flake8 (flake8 src)
serve (FLASK_APP=./hello.py flask run)
```

Fixes #152