### PR TITLE
Detect symlink behavior and document it better

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ that were not yet released.
 
 _Unreleased_
 
+- The installer on Windows now warns if symlinks are not enabled and directs
+  the user to enable developer mode.  The `--version` output now also
+  shows if symlinks are available.  #205
+
 - Support auto fix requires-python when conflict. #160
 
 - Added support for custom indexes.  #199

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,12 +510,12 @@ checksum = "850878694b7933ca4c9569d30a34b55031b9b139ee1fc7b94a527c4ef960d690"
 [[package]]
 name = "dialoguer"
 version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59c6f2989294b9a498d3ad5491a79c6deb604617378e1cdc4bfc1c1361fe2f87"
+source = "git+https://github.com/console-rs/dialoguer?rev=47a9d4df729db7ffc1492bd0845be786e6f20153#47a9d4df729db7ffc1492bd0845be786e6f20153"
 dependencies = [
  "console",
  "shell-words",
  "tempfile",
+ "thiserror",
  "zeroize",
 ]
 

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -18,6 +18,22 @@ on modern Windows versions.  Here is how you can enable it:
 4. Enable the toggle "Developer Mode"
 5. In the "Use developer features" dialog confirm by clicking "Yes".
 
+??? question "What happens if I don't enable it?"
+
+    Enabling symlinks is not strictly required as Rye automatically falls back to
+    hardlinks and junction points.  However not having symlinks enabled will ultimately
+    result in a worse user experience for the following reasons:
+
+    * Custom toolchain registration uses proxy files rather than actual symlinks which
+      means that the executables in the `.rye\py` path are non executable.
+    * All shims will be installed as hardlinks.  This can cause issues when upgrading
+      Rye while Python is in use.  These hardlinks will also continue to point to older
+      Rye executables creating more hard drive usage.
+    * Virtualenvs will be created with copies rather than symlinks.
+    * Junction points are used where symlinks to directories are otherwise used.  Some
+      tools might accidentally not detect junction points which can cause deletion of
+      virtualenvs to accidentally also delete or destroy the toolchain behind it.
+
 ## Python Interactive Prompt Input Messed Up
 
 The Python builds that Rye uses are compiled against `libedit` rather than `readline`

--- a/rye/Cargo.toml
+++ b/rye/Cargo.toml
@@ -41,7 +41,7 @@ walkdir = "2.3.3"
 which = "4.4.0"
 zstd = "0.12.3"
 sha2 = "0.10.6"
-dialoguer = "0.10.4"
+dialoguer = { git = "https://github.com/console-rs/dialoguer", rev = "47a9d4df729db7ffc1492bd0845be786e6f20153" }
 hex = "0.4.3"
 junction = "1.0.0"
 bzip2 = "0.4.4"

--- a/rye/src/cli/mod.rs
+++ b/rye/src/cli/mod.rs
@@ -26,6 +26,7 @@ mod uninstall;
 use git_testament::git_testament;
 
 use crate::bootstrap::SELF_PYTHON_VERSION;
+use crate::platform::symlinks_supported;
 
 git_testament!(TESTAMENT);
 
@@ -117,5 +118,6 @@ fn print_version() -> Result<(), Error> {
         std::env::consts::ARCH
     );
     eprintln!("self-python: {}", SELF_PYTHON_VERSION);
+    eprintln!("symlink support: {}", symlinks_supported());
     Ok(())
 }

--- a/rye/src/cli/rye.rs
+++ b/rye/src/cli/rye.rs
@@ -13,7 +13,7 @@ use same_file::is_same_file;
 use self_replace::self_delete_outside_path;
 
 use crate::bootstrap::{download_url, ensure_self_venv};
-use crate::platform::get_app_dir;
+use crate::platform::{get_app_dir, symlinks_supported};
 use crate::utils::{CommandOutput, QuietExit};
 
 #[cfg(windows)]
@@ -281,7 +281,10 @@ fn perform_install(mode: InstallMode) -> Result<(), Error> {
         eprintln!();
         eprintln!("Rye has detected that it's not installed on this computer yet and");
         eprintln!("automatically started the installer for you.  For more information");
-        eprintln!("read https://mitsuhiko.github.io/rye/guide/installation");
+        eprintln!(
+            "read {}",
+            style("https://rye-up.com/guide/installation/").yellow()
+        );
     }
 
     eprintln!();
@@ -297,6 +300,21 @@ fn perform_install(mode: InstallMode) -> Result<(), Error> {
     eprintln!("{}", style("Details:").bold());
     eprintln!("  Rye Version: {}", style(env!("CARGO_PKG_VERSION")).cyan());
     eprintln!("  Platform: {} ({})", style(OS).cyan(), style(ARCH).cyan());
+
+    if cfg!(windows) && !symlinks_supported() {
+        eprintln!();
+        eprintln!(
+            "{}: your Windows configuration does not support symlinks.",
+            style("Warning").red()
+        );
+        eprintln!();
+        eprintln!("It's strongly recommended that you enable developer mode in Windows to");
+        eprintln!("enable symlinks.  You need to enable this before continuing the setup.");
+        eprintln!(
+            "Learn more at {}",
+            style("https://rye-up.com/guide/faq/#windows-developer-mode").yellow()
+        );
+    }
 
     eprintln!();
     if !matches!(mode, InstallMode::NoPrompts)


### PR DESCRIPTION
This adds a helpful message to the installer when symlinks are unavailable on windows.

Fixes #203

Fixes #204