### PR TITLE
Remove redundant publish arg descriptions

### DIFF
--- a/rye/src/cli/publish.rs
+++ b/rye/src/cli/publish.rs
@@ -21,10 +21,10 @@ use crate::utils::{get_venv_python_bin, CommandOutput};
 pub struct Args {
     /// The distribution files to upload to the repository (defaults to <workspace-root>/dist/*).
     dist: Option<Vec<PathBuf>>,
-    /// The repository to publish to (defaults to 'pypi').
+    /// The repository to publish to.
     #[arg(short, long, default_value = "pypi")]
     repository: String,
-    /// The repository url to publish to (defaults to https://upload.pypi.org/legacy/).
+    /// The repository url to publish to.
     #[arg(long, default_value = "https://upload.pypi.org/legacy/")]
     repository_url: Url,
     /// An access token used for the upload.


### PR DESCRIPTION
Didn't realize this originally, but `--repository` and `--repository-url` have redundant "default" info.

Currently you'll get
```
❯ rye publish -h
Publish packages to a package repository

Usage: rye publish [OPTIONS] [DIST]...

Arguments:
  [DIST]...  The distribution files to upload to the repository (defaults to
             <workspace-root>/dist/*)

Options:
  -r, --repository <REPOSITORY>
          The repository to publish to (defaults to 'pypi') [default: pypi]
      --repository-url <REPOSITORY_URL>
          The repository url to publish to (defaults to
          https://upload.pypi.org/legacy/) [default:
          https://upload.pypi.org/legacy/]
      --token <TOKEN>
          An access token used for the upload
      --sign
          Sign files to upload using GPG
  -i, --identity <IDENTITY>
          GPG identity used to sign files
      --cert <CERT>
          Path to alternate CA bundle
  -v, --verbose
          Enables verbose diagnostics
  -q, --quiet
          Turns off all output
  -h, --help
          Print help
```