### PR TITLE
Add username args for rye publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ _Unreleased_
 
 Released on 2023-05-23
 
+- Add username args for rye publish.
+
 - Resolved a bug where on Windows hitting the shift key (or some other keys)
   in confirm prompts would cause an error.
 

--- a/rye/src/cli/publish.rs
+++ b/rye/src/cli/publish.rs
@@ -27,6 +27,9 @@ pub struct Args {
     /// The repository url to publish to (defaults to https://upload.pypi.org/legacy/).
     #[arg(long, default_value = "https://upload.pypi.org/legacy/")]
     repository_url: Url,
+    /// The username to authenticate to the repository with.
+    #[arg(short, long)]
+    username: Option<String>,
     /// An access token used for the upload.
     #[arg(long)]
     token: Option<String>,
@@ -67,6 +70,11 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
     if repository == "pypi" && cmd.repository_url.domain() != Some("upload.pypi.org") {
         bail!("invalid pypi url {} (use -h for help)", cmd.repository_url);
     }
+
+    let username = match cmd.username {
+        Some(username) => username,
+        None => "__token__".to_string(),
+    };
 
     let mut credentials = get_credentials()?;
     credentials
@@ -111,8 +119,8 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
         .arg("--no-color")
         .arg("upload")
         .args(files)
-        .arg("--user")
-        .arg("__token__")
+        .arg("--username")
+        .arg(username)
         .arg("--password")
         .arg(token.expose_secret())
         .arg("--repository-url")


### PR DESCRIPTION
Some package repositories need a `username` to upload packages, for example Google Artifact Register use `_json_key_base64` as a username: https://cloud.google.com/artifact-registry/docs/python/authentication

Tested with:

```
rye publish -r google --repository-url https://asia-northeast1-python.pkg.dev/shaped-infusion-348103/test/ --username _json_key_base64 --token ...
```