### PR TITLE
Only create a venv before shim resolution for rye managed projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ that were not yet released.
 
 _Unreleased_
 
+- The shims are now more resilient.  Previously a `pyproject.toml` file
+  caused in all cases a virtualenv to be created.  Now this will only
+  happen when the `rye.tool.managed` flag is set to `true`.  The old
+  behavior can be forced via the global config.
+
 <!-- released start -->
 
 ## 0.2.0

--- a/docs/guide/config.md
+++ b/docs/guide/config.md
@@ -51,6 +51,10 @@ requires-python = ">= 3.8"
 # This is the default toolchain that is used
 toolchain = "cpython@3.11.1"
 
+[behavior]
+# When set to true the `managed` flag is always assumed to be true.
+force_rye_managed = false
+
 # a array of tables with optional sources.  Same format as in pyproject.toml
 [[sources]]
 name = "default"

--- a/docs/guide/pyproject.md
+++ b/docs/guide/pyproject.md
@@ -42,9 +42,10 @@ excluded-dependencies = ["cffi"]
 
 ## `tool.rye.managed`
 
-This is a purely informational key that tells rye that this project is supposed to be managed
-by Rye.  This key is not changing any behavior in Rye, but it's a hint to better aid the
-user experience.
+This key tells rye that this project is supposed to be managed by Rye.  This key
+primarily affects some automatic creation of virtualenvs.  For instance Rye
+will not try to initialize a virtualenv when using shims without this flag.  It
+can be forced enabled in the global config.
 
 ```toml
 [tool.rye]

--- a/rye/src/config.rs
+++ b/rye/src/config.rs
@@ -89,6 +89,15 @@ impl Config {
         .context("failed to get default toolchain")
     }
 
+    /// Pretend that all projects are rye managed.
+    pub fn force_rye_managed(&self) -> bool {
+        self.doc
+            .get("behavior")
+            .and_then(|x| x.get("force_rye_managed"))
+            .and_then(|x| x.as_bool())
+            .unwrap_or(false)
+    }
+
     /// Returns the list of default sources.
     pub fn sources(&self) -> Result<Vec<SourceRef>, Error> {
         let mut rv = Vec::new();


### PR DESCRIPTION
Previously the transparent fallback did not properly work for some projects as a virtualenv always was created. This in particular is an issue that prevents me from using rye with sentry's relay project.