### PR TITLE
Fix the issue where tools that failed to install still appear

### DIFF
--- a/rye/src/installer.rs
+++ b/rye/src/installer.rs
@@ -118,6 +118,7 @@ pub fn install(
 
     let status = cmd.status()?;
     if !status.success() {
+        uninstall_helper(&target_venv_path, &shim_dir)?;
         bail!("tool installation failed");
     }
 


### PR DESCRIPTION
I can still see it with `rye tools list` after a failed install with `rye install hakuna`. It looks like this is caused by not cleaning up after the failure.

Before:
```
➜  o git:(main) ✗ rye tools install hakuna
ERROR: Could not find a version that satisfies the requirement hakuna (from versions: none)
ERROR: No matching distribution found for hakuna
Error: tool installation failed
➜  o git:(main) ✗ rye tools list
hakuna
...
```

After:
```
➜  o git:(main) ✗ rye tools install hakuna
ERROR: Could not find a version that satisfies the requirement hakuna (from versions: none)
ERROR: No matching distribution found for hakuna
Error: tool installation failed
➜  o git:(main) ✗ rye tools list
...

```