### PR TITLE
pyproject location argument for rye run, shell, show, build, pin

### DIFF
--- a/rye/src/cli/build.rs
+++ b/rye/src/cli/build.rs
@@ -27,6 +27,9 @@ pub struct Args {
     /// An output directory (defaults to `workspace/dist`)
     #[arg(short, long)]
     out: Option<PathBuf>,
+    /// Use this pyproject.toml file
+    #[arg(long, value_name = "PYPROJECT_TOML")]
+    pyproject: Option<PathBuf>,
     /// Enables verbose diagnostics.
     #[arg(short, long)]
     verbose: bool,
@@ -38,7 +41,7 @@ pub struct Args {
 pub fn execute(cmd: Args) -> Result<(), Error> {
     let output = CommandOutput::from_quiet_and_verbose(cmd.quiet, cmd.verbose);
     let venv = ensure_self_venv(output)?;
-    let project = PyProject::discover()?;
+    let project = PyProject::load_or_discover(cmd.pyproject.as_deref())?;
 
     let out = match cmd.out {
         Some(path) => path,

--- a/rye/src/cli/init.rs
+++ b/rye/src/cli/init.rs
@@ -148,14 +148,14 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
     // Write pyproject.toml
     let mut requires_python = match cmd.min_py {
         Some(py) => format!(">= {}", py),
-        None => get_python_version_request_from_pyenv_pin()
+        None => get_python_version_request_from_pyenv_pin(&dir)
             .map(|x| format!(">= {}.{}", x.major, x.minor.unwrap_or_default()))
             .unwrap_or_else(|| cfg.default_requires_python()),
     };
     let py = match cmd.py {
         Some(py) => PythonVersionRequest::from_str(&py)
             .map_err(|msg| anyhow!("invalid version: {}", msg))?,
-        None => match get_python_version_request_from_pyenv_pin() {
+        None => match get_python_version_request_from_pyenv_pin(&dir) {
             Some(ver) => ver,
             None => PythonVersionRequest::from(get_latest_cpython_version()?),
         },

--- a/rye/src/cli/pin.rs
+++ b/rye/src/cli/pin.rs
@@ -1,5 +1,6 @@
 use std::env;
 use std::fs;
+use std::path::PathBuf;
 
 use anyhow::Context;
 use anyhow::{anyhow, Error};
@@ -26,6 +27,9 @@ pub struct Args {
     /// Prevent updating requires-python in the pyproject.toml.
     #[arg(long)]
     no_update_requires_python: bool,
+    /// Use this pyproject.toml file
+    #[arg(long, value_name = "PYPROJECT_TOML")]
+    pyproject: Option<PathBuf>,
 }
 
 pub fn execute(cmd: Args) -> Result<(), Error> {
@@ -36,7 +40,7 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
     let to_write = get_pinnable_version(&req, cmd.relaxed)
         .ok_or_else(|| anyhow!("unsupported/unknown version for this platform"))?;
 
-    let pyproject = match PyProject::discover() {
+    let pyproject = match PyProject::load_or_discover(cmd.pyproject.as_deref()) {
         Ok(proj) => Some(proj),
         Err(err) => {
             if err.is::<DiscoveryUnsuccessful>() {

--- a/rye/src/cli/show.rs
+++ b/rye/src/cli/show.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+use std::path::PathBuf;
 use std::process::Command;
 
 use anyhow::{bail, Error};
@@ -16,10 +17,13 @@ pub struct Args {
     /// Print the installed dependencies from the venv
     #[arg(long)]
     installed_deps: bool,
+    /// Use this pyproject.toml file
+    #[arg(long, value_name = "PYPROJECT_TOML")]
+    pyproject: Option<PathBuf>,
 }
 
 pub fn execute(cmd: Args) -> Result<(), Error> {
-    let project = PyProject::discover()?;
+    let project = PyProject::load_or_discover(cmd.pyproject.as_deref())?;
 
     if cmd.installed_deps {
         return print_installed_deps(&project);

--- a/rye/src/cli/sync.rs
+++ b/rye/src/cli/sync.rs
@@ -59,6 +59,7 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
             features: cmd.features,
             all_features: cmd.all_features,
         },
+        pyproject: None,
     })?;
     Ok(())
 }

--- a/rye/src/platform.rs
+++ b/rye/src/platform.rs
@@ -195,16 +195,20 @@ pub fn get_default_author() -> Option<(String, String)> {
 }
 
 /// Reads the current `.python-version` file.
-pub fn get_python_version_request_from_pyenv_pin() -> Option<PythonVersionRequest> {
-    let mut here = env::current_dir().ok()?;
+pub fn get_python_version_request_from_pyenv_pin(root: &Path) -> Option<PythonVersionRequest> {
+    let mut here = root.to_owned();
 
     loop {
-        let ver_file = here.join(".python-version");
-        if let Ok(contents) = fs::read_to_string(&ver_file) {
+        here.push(".python-version");
+        if let Ok(contents) = fs::read_to_string(&here) {
             let ver = contents.trim().parse().ok()?;
             return Some(ver);
         }
 
+        // pop filename
+        here.pop();
+
+        // pop parent
         if !here.pop() {
             break;
         }

--- a/rye/src/pyproject.rs
+++ b/rye/src/pyproject.rs
@@ -5,6 +5,7 @@ use std::collections::{HashMap, HashSet};
 use std::env;
 use std::env::consts::{ARCH, OS};
 use std::ffi::OsStr;
+use std::ffi::OsString;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -461,6 +462,7 @@ impl fmt::Display for DiscoveryUnsuccessful {
 #[derive(Debug)]
 pub struct PyProject {
     root: PathBuf,
+    basename: OsString,
     workspace: Option<Arc<Workspace>>,
     doc: Document,
 }
@@ -503,8 +505,14 @@ impl PyProject {
             }
         }
 
+        let basename = match filename.file_name() {
+            Some(name) => name.to_os_string(),
+            None => bail!("project {} has no file name", root.display()),
+        };
+
         Ok(PyProject {
             root: root.to_owned(),
+            basename,
             workspace,
             doc,
         })
@@ -532,8 +540,14 @@ impl PyProject {
             return Ok(None);
         }
 
+        let basename = match filename.file_name() {
+            Some(name) => name.to_os_string(),
+            None => bail!("project {} has no file name", root.display()),
+        };
+
         Ok(Some(PyProject {
             root: root.to_owned(),
+            basename,
             workspace: Some(workspace),
             doc,
         }))
@@ -569,7 +583,7 @@ impl PyProject {
 
     /// Returns the path to the toml file.
     pub fn toml_path(&self) -> Cow<'_, Path> {
-        Cow::Owned(self.root.join("pyproject.toml"))
+        Cow::Owned(self.root.join(&self.basename))
     }
 
     /// Returns the location of the virtualenv.

--- a/rye/src/pyproject.rs
+++ b/rye/src/pyproject.rs
@@ -468,6 +468,17 @@ pub struct PyProject {
 }
 
 impl PyProject {
+    /// Load a pyproject toml if explicitly given, else discover from current directory
+    ///
+    /// Used for command line arguments.
+    pub fn load_or_discover(arg: Option<&Path>) -> Result<PyProject, Error> {
+        match arg {
+            // canonicalize because it comes from a command line argument
+            Some(path) => Self::load(&path.canonicalize()?),
+            None => Self::discover(),
+        }
+    }
+
     /// Discovers and loads a pyproject toml.
     pub fn discover() -> Result<PyProject, Error> {
         let pyproject_toml = match find_project_root() {


### PR DESCRIPTION
This enables using rye outside of its project home.

Some refactoring to make rye less sensitive to its current working directory:

1. `.python-version` searching is now relative to `pyproject.toml` if we have a project
2. PyProject saves the filename (so that it can write the same filename again later in add, remove, pin)

SyncMode::PythonOnly can support a custom pyproject location for now. The rest of the lock/sync
machinery would need more work. PythonOnly sync is needed to support `rye run` and `rye shell`.

### Example
```
#  run python from the environment in a project over there
rye run --pyproject ./path/to/project/pyproject.toml python3

# Show info about a project
rye show --pyproject <a project.toml>
```

I'd like to add `--pyproject` to every applicable command. But these are left and need resolution later:

-  `lock` and `sync`: relative path logic, `pyproject.toml` default for pip tools(?) and the role of the `.` path in the lockfile
- `add` and `remove`: relative path logic in `add`. (Remove should be added with add.)