### PR TITLE
Emit a PTH file to find TCL

### DIFF
--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -51,9 +51,9 @@ resolve this:
 
 TKinter uses TCL behind the scenes.  Unfortunately this also means that some runtime
 support is required.  This runtime support is provided by the portable Python builds,
-however the way TCL is initialized on macOS and Linux won't find these files.  The
-easiest way to accomplish this is to export the `TCL_LIBRARY` and `TK_LIBRARY`
-environment variables before you import tkinter:
+however the way TCL is initialized on macOS and Linux won't find these files in
+virtualenvs.  Newer versions of Rye will automatically export the `TCL_LIBRARY`
+and `TK_LIBRARY` environment variables for you in a manner very similar to this:
 
 ```python
 import os
@@ -61,9 +61,6 @@ import sys
 os.environ["TCL_LIBRARY"] = sys.base_prefix + "/lib/tcl8.6"
 os.environ["TK_LIBRARY"] = sys.base_prefix + "/lib/tk8.6"
 ```
-
-There is a desire to make this process automatic in the future, but for now this is
-a workaround to get you unblocked.
 
 ## Python Interactive Prompt Input Messed Up
 

--- a/rye/src/sync.rs
+++ b/rye/src/sync.rs
@@ -291,5 +291,55 @@ pub fn create_virtualenv(
     if !status.success() {
         bail!("failed to initialize virtualenv");
     }
+
+    #[cfg(unix)]
+    {
+        inject_tcl_config(venv, &py_bin, py_ver)?;
+    }
+
+    Ok(())
+}
+
+/// On UNIX systems Python is unable to find the tcl config that is placed outside of the
+/// virtualenv.  It also sometimes is entirely unable to find the tcl config that comes
+/// from the standalone python builds.
+#[cfg(unix)]
+fn inject_tcl_config(venv: &Path, py_bin: &Path, py_ver: &PythonVersion) -> Result<(), Error> {
+    let lib_path = match py_bin
+        .parent()
+        .and_then(|x| x.parent())
+        .map(|x| x.join("lib"))
+    {
+        Some(path) => path,
+        None => return Ok(()),
+    };
+
+    let tcl_lib = lib_path.join("tcl8.6");
+    let tcl_lib_exists = tcl_lib.is_dir();
+    let tk_lib = lib_path.join("tk8.6");
+    let tk_lib_exists = tk_lib.is_dir();
+    let site_packages = venv
+        .join("lib")
+        .join(format!("python{}.{}", py_ver.major, py_ver.minor))
+        .join("site-packages");
+
+    if !(tk_lib_exists || tcl_lib_exists) {
+        return Ok(());
+    }
+
+    let pth = minijinja::render!(
+        r#"import os, sys;
+{%- if tcl_lib_exists -%}
+os.environ.setdefault('TCL_LIBRARY', sys.base_prefix + '/lib/tcl8.6');
+{%- endif -%}
+{%- if tk_lib_exists -%}
+os.environ.setdefault('TK_LIBRARY', sys.base_prefix + '/lib/tk8.6');
+{%- endif -%}"#,
+        tcl_lib_exists,
+        tk_lib_exists,
+    );
+
+    fs::write(site_packages.join("_tcl-init.pth"), pth)?;
+
     Ok(())
 }

--- a/rye/src/sync.rs
+++ b/rye/src/sync.rs
@@ -292,6 +292,9 @@ pub fn create_virtualenv(
         bail!("failed to initialize virtualenv");
     }
 
+    // On UNIX systems Python is unable to find the tcl config that is placed
+    // outside of the virtualenv.  It also sometimes is entirely unable to find
+    // the tcl config that comes from the standalone python builds.
     #[cfg(unix)]
     {
         inject_tcl_config(venv, &py_bin, py_ver)?;
@@ -300,9 +303,6 @@ pub fn create_virtualenv(
     Ok(())
 }
 
-/// On UNIX systems Python is unable to find the tcl config that is placed outside of the
-/// virtualenv.  It also sometimes is entirely unable to find the tcl config that comes
-/// from the standalone python builds.
 #[cfg(unix)]
 fn inject_tcl_config(venv: &Path, py_bin: &Path, py_ver: &PythonVersion) -> Result<(), Error> {
     let lib_path = match py_bin
@@ -314,32 +314,53 @@ fn inject_tcl_config(venv: &Path, py_bin: &Path, py_ver: &PythonVersion) -> Resu
         None => return Ok(()),
     };
 
-    let tcl_lib = lib_path.join("tcl8.6");
-    let tcl_lib_exists = tcl_lib.is_dir();
-    let tk_lib = lib_path.join("tk8.6");
-    let tk_lib_exists = tk_lib.is_dir();
+    let mut tcl_lib = None;
+    let mut tk_lib = None;
+
+    if let Ok(dir) = lib_path.read_dir() {
+        for entry in dir.filter_map(|x| x.ok()) {
+            let filename = entry.file_name();
+            let name = match filename.to_str() {
+                Some(name) => name,
+                None => continue,
+            };
+            if name.starts_with("tcl8") {
+                tcl_lib = Some(name.to_string());
+                if tk_lib.is_some() {
+                    break;
+                }
+            } else if name.starts_with("tk8") {
+                tk_lib = Some(name.to_string());
+                if tcl_lib.is_some() {
+                    break;
+                }
+            }
+        }
+    }
+
     let site_packages = venv
         .join("lib")
         .join(format!("python{}.{}", py_ver.major, py_ver.minor))
         .join("site-packages");
 
-    if !(tk_lib_exists || tcl_lib_exists) {
+    if tk_lib.is_none() && tcl_lib.is_none() {
         return Ok(());
     }
 
-    let pth = minijinja::render!(
-        r#"import os, sys;
-{%- if tcl_lib_exists -%}
-os.environ.setdefault('TCL_LIBRARY', sys.base_prefix + '/lib/tcl8.6');
+    fs::write(
+        site_packages.join("_tcl-init.pth"),
+        minijinja::render!(
+            r#"import os, sys;
+{%- if tcl_lib -%}
+os.environ.setdefault('TCL_LIBRARY', sys.base_prefix + '/lib/{{ tcl_lib }}');
 {%- endif -%}
-{%- if tk_lib_exists -%}
-os.environ.setdefault('TK_LIBRARY', sys.base_prefix + '/lib/tk8.6');
+{%- if tk_lib -%}
+os.environ.setdefault('TK_LIBRARY', sys.base_prefix + '/lib/{{ tk_lib }}');
 {%- endif -%}"#,
-        tcl_lib_exists,
-        tk_lib_exists,
-    );
-
-    fs::write(site_packages.join("_tcl-init.pth"), pth)?;
+            tcl_lib,
+            tk_lib,
+        ),
+    )?;
 
     Ok(())
 }


### PR DESCRIPTION
This is a creative workaround for #226

The downside is that it exports two environment variables into all python processes on unix, but maybe that's reasonable.