### PR TITLE
Fix invalid version error when using  rye init with custom toolchain

### DIFF
--- a/rye/src/sources.rs
+++ b/rye/src/sources.rs
@@ -91,6 +91,23 @@ impl fmt::Display for PythonVersion {
     }
 }
 
+impl From<PythonVersion> for Version {
+    fn from(value: PythonVersion) -> Self {
+        Version {
+            epoch: 0,
+            release: vec![
+                value.major as usize,
+                value.minor as usize,
+                value.patch as usize,
+            ],
+            pre: None,
+            post: None,
+            dev: None,
+            local: None,
+        }
+    }
+}
+
 /// Internal descriptor for a python version request.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone)]
 pub struct PythonVersionRequest {


### PR DESCRIPTION
fixes https://github.com/mitsuhiko/rye/issues/231.

This was originally caused by https://github.com/mitsuhiko/rye/pull/202.