### PR TITLE
allow overriding the install option via install.sh

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,6 +7,8 @@ __wrap__() {
 
 # allow overriding the version
 VERSION=${RYE_VERSION:-latest}
+# allow overriding the install option
+INSTALL_OPTION=${RYE_INSTALL_OPTION:-""}
 
 REPO=mitsuhiko/rye
 PLATFORM=`uname -s`
@@ -66,6 +68,6 @@ fi
 rm -f "$TEMP_FILE"
 gunzip "$TEMP_FILE_GZ" 
 chmod +x "$TEMP_FILE"
-"$TEMP_FILE" self install
+"$TEMP_FILE" self install $INSTALL_OPTION
 
 }; __wrap__


### PR DESCRIPTION
I added `RYE_INSTALL_OPTION` environment variable to override the install option via install.sh script.

Solve https://github.com/mitsuhiko/rye/issues/246

Expected usage

```dockerfile
FROM python:3.11

ENV RYE_INSTALL_OPTION=-y

RUN curl -sSf https://rye-up.com/get | bash

CMD ["python3"]
```