### PR TITLE
Fix rye init for flit

### DIFF
--- a/rye/src/cli/init.rs
+++ b/rye/src/cli/init.rs
@@ -22,7 +22,7 @@ use crate::utils::is_inside_git_work_tree;
 pub enum BuildSystem {
     Hatchling,
     Setuptools,
-    Filt,
+    Flit,
     Pdm,
 }
 


### PR DESCRIPTION
Spelling `Filt` made it impossible to init a project to use flit.