### PR TITLE
Default build-system and license can be specified in global config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ that were not yet released.
 
 _Unreleased_
 
+- Default license can be specified in global config.  #244
+
 - Fixed an issue where the `init` command would not let you create
   `flit` based projects.  #254
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ that were not yet released.
 
 _Unreleased_
 
-- Default license can be specified in global config.  #244
+- Default build-system and license can be specified in global config.  #244
 
 - Fixed an issue where the `init` command would not let you create
   `flit` based projects.  #254

--- a/docs/guide/config.md
+++ b/docs/guide/config.md
@@ -51,6 +51,12 @@ requires-python = ">= 3.8"
 # This is the default toolchain that is used
 toolchain = "cpython@3.11.1"
 
+# This is the default build system that is used
+build-system = "hatchling"
+
+# This is the default license that is used
+license = "MIT"
+
 [proxy]
 # the proxy to use for HTTP (overridden by the http_proxy environment variable)
 http = "http://127.0.0.1:4000"

--- a/rye/src/cli/add.rs
+++ b/rye/src/cli/add.rs
@@ -13,7 +13,7 @@ use url::Url;
 
 use crate::bootstrap::ensure_self_venv;
 use crate::consts::VENV_BIN;
-use crate::pyproject::{DependencyKind, ExpandedSources, PyProject};
+use crate::pyproject::{BuildSystem, DependencyKind, ExpandedSources, PyProject};
 use crate::utils::{format_requirement, set_proxy_variables, CommandOutput};
 
 const PACKAGE_FINDER_SCRIPT: &str = r#"
@@ -126,7 +126,8 @@ impl ReqExtras {
             // For hatchling build backend, it use {root:uri} for file relative path,
             // but this not supported by pip-tools,
             // and use ${PROJECT_ROOT} will cause error in hatchling, so force absolute path.
-            let is_hatchling = PyProject::discover()?.build_backend().unwrap() == "hatchling";
+            let is_hatchling =
+                PyProject::discover()?.build_backend().unwrap() == BuildSystem::Hatchling;
             let file_url = if self.absolute || is_hatchling {
                 Url::from_file_path(env::current_dir()?.join(path))
                     .map_err(|_| anyhow!("unable to interpret '{}' as path", path.display()))?

--- a/rye/src/cli/init.rs
+++ b/rye/src/cli/init.rs
@@ -175,25 +175,26 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
     );
     let version = "0.1.0";
     let author = get_default_author();
-    let license = if let Some(license) = cmd.license {
-        if !license_file.is_file() {
-            let license_obj: &dyn License = license
-                .parse()
-                .expect("current license not an valid license id");
-            let license_text = license_obj.text();
-            let rv = env.render_named_str(
-                "LICENSE.txt",
-                LICENSE_TEMPLATE,
-                context! {
-                    license_text,
-                },
-            )?;
-            fs::write(&license_file, rv)?;
-        };
-        Some(license)
-    } else {
-        None
+    let license = match cmd.license {
+        Some(license) => Some(license),
+        None => cfg.default_license(),
     };
+    if license.is_some() && !license_file.is_file() {
+        let license_obj: &dyn License = license
+            .clone()
+            .unwrap()
+            .parse()
+            .expect("current license not an valid license id");
+        let license_text = license_obj.text();
+        let rv = env.render_named_str(
+            "LICENSE.txt",
+            LICENSE_TEMPLATE,
+            context! {
+                license_text,
+            },
+        )?;
+        fs::write(&license_file, rv)?;
+    }
 
     // write .python-version
     if !cmd.no_pin && !python_version_file.is_file() {

--- a/rye/src/cli/init.rs
+++ b/rye/src/cli/init.rs
@@ -34,7 +34,7 @@ pub struct Args {
     /// Do not create .python-version file (requires-python will be used)
     #[arg(long)]
     no_pin: bool,
-    /// Which build system should be used?
+    /// Which build system should be used(defaults to hatchling)?
     #[arg(long)]
     build_system: Option<BuildSystem>,
     /// Which license should be used (SPDX identifier)?

--- a/rye/src/config.rs
+++ b/rye/src/config.rs
@@ -91,11 +91,15 @@ impl Config {
 
     /// Returns the default build system
     pub fn default_build_system(&self) -> Option<BuildSystem> {
-        self.doc
+        match self
+            .doc
             .get("default")
             .and_then(|x| x.get("build-system"))
             .and_then(|x| x.as_str())
-            .map(|x| x.to_string().parse::<BuildSystem>().unwrap())
+        {
+            Some(build_system) => build_system.parse::<BuildSystem>().ok(),
+            None => None,
+        }
     }
 
     /// Returns the default license

--- a/rye/src/config.rs
+++ b/rye/src/config.rs
@@ -89,12 +89,22 @@ impl Config {
         .context("failed to get default toolchain")
     }
 
+    /// Returns the default build system
     pub fn default_build_system(&self) -> Option<BuildSystem> {
         self.doc
             .get("default")
             .and_then(|x| x.get("build-system"))
             .and_then(|x| x.as_str())
             .map(|x| x.to_string().parse::<BuildSystem>().unwrap())
+    }
+
+    /// Returns the default license
+    pub fn default_license(&self) -> Option<String> {
+        self.doc
+            .get("default")
+            .and_then(|x| x.get("license"))
+            .and_then(|x| x.as_str())
+            .map(|x| x.to_string())
     }
 
     /// Pretend that all projects are rye managed.

--- a/rye/src/config.rs
+++ b/rye/src/config.rs
@@ -6,7 +6,7 @@ use anyhow::{Context, Error};
 use toml_edit::Document;
 
 use crate::platform::{get_app_dir, get_latest_cpython};
-use crate::pyproject::{SourceRef, SourceRefType};
+use crate::pyproject::{BuildSystem, SourceRef, SourceRefType};
 use crate::sources::PythonVersionRequest;
 
 static CONFIG: Mutex<Option<Arc<Config>>> = Mutex::new(None);
@@ -87,6 +87,14 @@ impl Config {
             None => get_latest_cpython().map(Into::into),
         }
         .context("failed to get default toolchain")
+    }
+
+    pub fn default_build_system(&self) -> Option<BuildSystem> {
+        self.doc
+            .get("default")
+            .and_then(|x| x.get("build-system"))
+            .and_then(|x| x.as_str())
+            .map(|x| x.to_string().parse::<BuildSystem>().unwrap())
     }
 
     /// Pretend that all projects are rye managed.

--- a/rye/src/pyproject.rs
+++ b/rye/src/pyproject.rs
@@ -1,3 +1,4 @@
+use clap::ValueEnum;
 use core::fmt;
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
@@ -612,16 +613,17 @@ impl PyProject {
     }
 
     /// Returns the build backend.
-    pub fn build_backend(&self) -> Option<&str> {
+    pub fn build_backend(&self) -> Option<BuildSystem> {
         let backend = self
             .doc
             .get("build-system")
             .and_then(|x| x.get("build-backend"))
             .and_then(|x| x.as_str());
         match backend {
-            Some("hatchling.build") => Some("hatchling"),
-            Some("setuptools.build_meta") => Some("setuptools"),
-            Some("flit_core.buildapi") => Some("flit"),
+            Some("hatchling.build") => Some(BuildSystem::Hatchling),
+            Some("setuptools.build_meta") => Some(BuildSystem::Setuptools),
+            Some("flit_core.buildapi") => Some(BuildSystem::Flit),
+            Some("pdm.backend") => Some(BuildSystem::Pdm),
             _ => None,
         }
     }
@@ -1040,6 +1042,30 @@ impl ExpandedSources {
         for host in &self.trusted_hosts {
             cmd.arg("--trusted-host");
             cmd.arg(host);
+        }
+    }
+}
+
+#[derive(ValueEnum, Copy, Clone, Serialize, Debug, PartialEq)]
+#[value(rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
+pub enum BuildSystem {
+    Hatchling,
+    Setuptools,
+    Flit,
+    Pdm,
+}
+
+impl FromStr for BuildSystem {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "hatchling" => Ok(BuildSystem::Hatchling),
+            "setuptools" => Ok(BuildSystem::Setuptools),
+            "flit" => Ok(BuildSystem::Flit),
+            "pdm" => Ok(BuildSystem::Pdm),
+            _ => Err(anyhow!("unknown build system")),
         }
     }
 }


### PR DESCRIPTION
closes https://github.com/mitsuhiko/rye/issues/244

```
 ➜  o git:(main) ✗ cat ~/.rye/config.toml
[default]
build-system = "pdm"
license = "MIT"

[[sources]]
name = "dou"
url = "https://pypi.sapps.douban/simple"

➜  o git:(main) ✗ rye init
success: Initialized project in /Users/zhezhezhu/projects/test/o/.
  Run `rye sync` to get started
(douban) ➜  o git:(main) ✗ cat pyproject.toml
[project]
name = "o"
version = "0.1.0"
description = "Add a short description here"
authors = [
    { name = "Chaojie", email = "hi@chaojie.fun" }
]
dependencies = []
readme = "README.md"
requires-python = ">= 3.11"
license = { text = "MIT" }

[build-system]
requires = ["pdm-backend"]
build-backend = "pdm.backend"

[tool.rye]
managed = true
```