### PR TITLE
Skip .venv and .git when searching workspace

### DIFF
--- a/rye/src/pyproject.rs
+++ b/rye/src/pyproject.rs
@@ -381,6 +381,7 @@ impl Workspace {
                 Ok(entry) => {
                     if entry.file_type().is_file()
                         && entry.file_name() == OsStr::new("pyproject.toml")
+                        && self.is_member(entry.path().parent().unwrap())
                     {
                         let project =
                             match PyProject::load_with_workspace(entry.path(), self.clone()) {
@@ -388,9 +389,7 @@ impl Workspace {
                                 Ok(None) => return None,
                                 Err(err) => return Some(Err(err)),
                             };
-                        if self.is_member(entry.path().parent().unwrap()) {
-                            return Some(Ok(project));
-                        }
+                        return Some(Ok(project));
                     }
                     None
                 }

--- a/rye/src/pyproject.rs
+++ b/rye/src/pyproject.rs
@@ -374,6 +374,9 @@ impl Workspace {
     ) -> impl Iterator<Item = Result<PyProject, Error>> + 'a {
         walkdir::WalkDir::new(&self.root)
             .into_iter()
+            .filter_entry(|entry| {
+                !(entry.file_type().is_dir() && skip_recurse_into(entry.file_name()))
+            })
             .filter_map(move |entry| match entry {
                 Ok(entry) => {
                     if entry.file_type().is_file()
@@ -436,6 +439,11 @@ impl Workspace {
     pub fn rye_managed(&self) -> bool {
         is_rye_managed(&self.doc)
     }
+}
+
+/// Check if recurse should be skipped into directory with this name
+fn skip_recurse_into(name: &OsStr) -> bool {
+    return name == OsStr::new(".venv") || name == OsStr::new(".git");
 }
 
 /// Helps working with pyproject.toml files


### PR DESCRIPTION
Skip .venv since it can contain stray pyprojects that are not related to
the current project. Further items could be ignored here.

Correctness fix (previously pyproject.toml installed into some package
in the environment, could ruin the sync), as well as a speed up since we
can skip scanning all the files in the environment.

Also change the order of member check and loading the project, it
seemed better to me in this order.

Fixes #260