### PR TITLE
Allow using system python for self environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ that were not yet released.
 
 _Unreleased_
 
+- Rye will no longer enforce a downloaded interpreter for the internal
+  toolchain.  If one has been registered that is compatible it will be
+  used.  Additionally the installer now supports the `RYE_TOOLCHAIN`
+  environment variable which allows a user to supply an already existing
+  Python interpreter at install time.  #267
+
 - When a Python debug build (`Py_DEBUG`) is registered as custom toolchain,
   `-dbg` is automatically appended to the name by default.  #269
 

--- a/docs/.includes/curl-to-bash-options.md
+++ b/docs/.includes/curl-to-bash-options.md
@@ -9,6 +9,8 @@ variables:
 
 :   Can optionally be set to `"--yes"` to skip all prompts.
 
+{% include-markdown "../.includes/installer-options.md" %}
+
 This for instance installs a specific version of Rye without asking questions:
 
 ```bash

--- a/docs/.includes/installer-options.md
+++ b/docs/.includes/installer-options.md
@@ -4,4 +4,4 @@
     interpreter that should be used as the internal interpreter.  If not
     provided a suitable interpreter is automatically downloaded.
 
-    At present only CPython 3.8 to 3.11 are supported.
+    At present only CPython 3.9 to 3.11 are supported.

--- a/docs/.includes/installer-options.md
+++ b/docs/.includes/installer-options.md
@@ -1,0 +1,7 @@
+`RYE_TOOLCHAIN`
+
+:   Optionally this environment variable can be set to point to a Python
+    interpreter that should be used as the internal interpreter.  If not
+    provided a suitable interpreter is automatically downloaded.
+
+    At present only CPython 3.8 to 3.11 are supported.

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -31,7 +31,17 @@ experience.
 
 === "Windows"
 
-    The Windows installer does not support customizations.
+    The Windows installer has limited support for customizations via environment
+    variables.  To set these you need to run the installer from `cmd.exe`.
+
+    {% include-markdown "../.includes/installer-options.md" %}
+
+    This for instance installs Rye with a specific toolchain:
+
+    ```batch
+    set RYE_TOOLCHAIN=%USERPROFILE%\AppData\Local\Programs\Python\Python310\python.exe
+    rye-x86_64-windows.exe
+    ```
 
 ## Add Shims to Path
 

--- a/rye/src/bootstrap.rs
+++ b/rye/src/bootstrap.rs
@@ -18,24 +18,21 @@ use crate::platform::{
     get_app_dir, get_canonical_py_path, get_toolchain_python_bin, list_known_toolchains,
     symlinks_supported,
 };
-use crate::sources::{get_download_url, matches_version, PythonVersion, PythonVersionRequest};
+use crate::sources::{get_download_url, PythonVersion, PythonVersionRequest};
 use crate::utils::{
     check_checksum, set_proxy_variables, symlink_file, unpack_archive, CommandOutput,
 };
 
-pub const SELF_PYTHON_VERSION: PythonVersionRequest = PythonVersionRequest {
+/// this is the target version that we want to fetch
+pub const SELF_PYTHON_TARGET_VERSION: PythonVersionRequest = PythonVersionRequest {
     kind: Some(Cow::Borrowed("cpython")),
     major: 3,
     minor: Some(10),
     patch: None,
     suffix: None,
 };
-const SELF_VERSION: u64 = 3;
 
-#[cfg(unix)]
-const SELF_SITE_PACKAGES: &str = "python3.10/site-packages";
-#[cfg(windows)]
-const SELF_SITE_PACKAGES: &str = "site-packages";
+const SELF_VERSION: u64 = 3;
 
 const SELF_REQUIREMENTS: &str = r#"
 build==0.10.0
@@ -93,10 +90,10 @@ pub fn ensure_self_venv(output: CommandOutput) -> Result<PathBuf, Error> {
         eprintln!("Bootstrapping rye internals");
     }
 
-    let version = ensure_toolchain(&SELF_PYTHON_VERSION, output).with_context(|| {
+    let version = ensure_self_toolchain(output).with_context(|| {
         format!(
             "failed to fetch internal cpython toolchain {}",
-            SELF_PYTHON_VERSION
+            SELF_PYTHON_TARGET_VERSION
         )
     })?;
     let py_bin = get_toolchain_python_bin(&version)?;
@@ -233,33 +230,71 @@ pub fn update_core_shims(shims: &Path, this: &Path) -> Result<(), Error> {
 }
 
 /// Returns the pip runner for the self venv
-pub fn get_pip_runner(venv: &Path) -> PathBuf {
-    get_pip_module(venv).join("__pip-runner__.py")
+pub fn get_pip_runner(venv: &Path) -> Result<PathBuf, Error> {
+    Ok(get_pip_module(venv)?.join("__pip-runner__.py"))
 }
 
 /// Returns the pip module for the self venv
-pub fn get_pip_module(venv: &Path) -> PathBuf {
+pub fn get_pip_module(venv: &Path) -> Result<PathBuf, Error> {
     let mut rv = venv.to_path_buf();
     rv.push("lib");
-    rv.push(SELF_SITE_PACKAGES);
-    rv.push("pip");
-    rv
-}
-
-pub fn ensure_toolchain(
-    req: &PythonVersionRequest,
-    output: CommandOutput,
-) -> Result<PythonVersion, Error> {
-    for (version, path) in list_known_toolchains()? {
-        if matches_version(req, &version) {
-            if output != CommandOutput::Quiet {
-                let path = path.to_string_lossy();
-                eprintln!("Found a matching python version: {version}, path: {path}")
+    #[cfg(windows)]
+    {
+        rv.push("site-packages");
+    }
+    #[cfg(unix)]
+    {
+        // This is not optimal.  We find the first thing that
+        // looks like pythonX.X/site-packages and just use it.
+        // It also means that this requires us to do some unnecessary
+        // file system operations.  However given how hopefully
+        // infrequent this function is called, we might be good.
+        let dir = rv.read_dir()?;
+        let mut found = false;
+        for entry in dir.filter_map(|x| x.ok()) {
+            let filename = entry.file_name();
+            if let Some(filename) = filename.to_str() {
+                if filename.starts_with("python") {
+                    rv.push(filename);
+                    rv.push("site-packages");
+                    if rv.is_dir() {
+                        found = true;
+                        break;
+                    } else {
+                        rv.pop();
+                        rv.pop();
+                    }
+                }
             }
-            return Ok(version);
+        }
+        if !found {
+            bail!("no site-packages in venv");
         }
     }
-    fetch(req, output)
+    rv.push("pip");
+    Ok(rv)
+}
+
+fn ensure_self_toolchain(output: CommandOutput) -> Result<PythonVersion, Error> {
+    let mut possible_versions = Vec::new();
+    for (version, _) in list_known_toolchains()? {
+        // we only support cpython 3.9 to 3.11
+        if version.kind == "cpython"
+            && version.major == 3
+            && version.minor >= 9
+            && version.minor < 12
+        {
+            possible_versions.push(version);
+        }
+    }
+
+    if possible_versions.is_empty() {}
+    if let Some(version) = possible_versions.into_iter().min() {
+        eprintln!("Found a compatible python version: {version}");
+        Ok(version)
+    } else {
+        fetch(&SELF_PYTHON_TARGET_VERSION, output)
+    }
 }
 /// Fetches a version if missing.
 pub fn fetch(

--- a/rye/src/bootstrap.rs
+++ b/rye/src/bootstrap.rs
@@ -288,7 +288,10 @@ fn ensure_self_toolchain(output: CommandOutput) -> Result<PythonVersion, Error> 
         .collect::<Vec<_>>();
 
     if let Some(version) = possible_versions.into_iter().min() {
-        eprintln!("Found a compatible python version: {version}");
+        eprintln!(
+            "Found a compatible python version: {}",
+            style(&version).cyan()
+        );
         Ok(version)
     } else {
         fetch(&SELF_PYTHON_TARGET_VERSION, output)

--- a/rye/src/cli/mod.rs
+++ b/rye/src/cli/mod.rs
@@ -25,7 +25,7 @@ mod uninstall;
 
 use git_testament::git_testament;
 
-use crate::bootstrap::SELF_PYTHON_VERSION;
+use crate::bootstrap::SELF_PYTHON_TARGET_VERSION;
 use crate::platform::symlinks_supported;
 
 git_testament!(TESTAMENT);
@@ -117,7 +117,7 @@ fn print_version() -> Result<(), Error> {
         std::env::consts::OS,
         std::env::consts::ARCH
     );
-    eprintln!("self-python: {}", SELF_PYTHON_VERSION);
+    eprintln!("self-python: {}", SELF_PYTHON_TARGET_VERSION);
     eprintln!("symlink support: {}", symlinks_supported());
     Ok(())
 }

--- a/rye/src/cli/rye.rs
+++ b/rye/src/cli/rye.rs
@@ -408,7 +408,10 @@ fn perform_install(mode: InstallMode, toolchain_path: Option<&Path>) -> Result<(
 
     // Register a toolchain if provided.
     if let Some(toolchain_path) = toolchain_path {
-        eprintln!("Registering toolchain at {}", toolchain_path.display());
+        eprintln!(
+            "Registering toolchain at {}",
+            style(toolchain_path.display()).cyan()
+        );
         let version = register_toolchain(toolchain_path, None, |ver| {
             if ver.kind != "cpython" {
                 bail!("Only cpython toolchains are allowed, got '{}'", ver.kind);

--- a/rye/src/cli/shim.rs
+++ b/rye/src/cli/shim.rs
@@ -48,7 +48,7 @@ fn get_pip_shim(
     output: CommandOutput,
 ) -> Result<Vec<OsString>, Error> {
     let venv = ensure_self_venv(output)?;
-    let runner = get_pip_runner(&venv);
+    let runner = get_pip_runner(&venv).context("could not locate pip")?;
     let python = get_venv_python_bin(&pyproject.venv_path());
 
     // pip likes to emit deprecation warnings

--- a/rye/src/cli/toolchain.rs
+++ b/rye/src/cli/toolchain.rs
@@ -2,7 +2,7 @@ use std::cmp::Reverse;
 use std::collections::HashMap;
 use std::env::consts::{ARCH, OS};
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use anyhow::{bail, Context, Error};
@@ -86,65 +86,8 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
 }
 
 fn register(cmd: RegisterCommand) -> Result<(), Error> {
-    let output = Command::new(&cmd.path)
-        .arg("-c")
-        .arg(INSPECT_SCRIPT)
-        .output()
-        .context("error executing interpreter to inspect version")?;
-    if !output.status.success() {
-        bail!("passed path does not appear to be a valid Python installation");
-    }
-
-    let info: InspectInfo = serde_json::from_slice(&output.stdout)
-        .context("could not parse interpreter output as json")?;
-    let target_version = match cmd.name {
-        Some(ref name) => format!("{}@{}", name, info.python_version),
-        None => {
-            format!(
-                "{}{}@{}",
-                info.python_implementation.to_ascii_lowercase(),
-                if info.python_debug { "-dbg" } else { "" },
-                info.python_version
-            )
-        }
-    };
-    let target_version: PythonVersion = target_version.parse()?;
-    let target = get_canonical_py_path(&target_version)?;
-
-    if target.is_file() || target.is_dir() {
-        bail!("target Python path {} is already in use", target.display());
-    }
-
-    // for the unlikely case that no python installation has been bootstrapped yet
-    if let Some(parent) = target.parent() {
-        fs::create_dir_all(parent).ok();
-    }
-
-    // on unix we always create a symlink
-    #[cfg(unix)]
-    {
-        symlink_file(&cmd.path, target).context("could not symlink interpreter")?;
-    }
-
-    // on windows on the other hand we try a symlink first, but if that fails we fall back
-    // to writing the interpreter into the text file.  This is also supported by the
-    // interpreter lookup (see: get_toolchain_python_bin).  This is done because symlinks
-    // require higher privileges.
-    #[cfg(windows)]
-    {
-        if symlink_file(&cmd.path, &target).is_err() {
-            fs::write(
-                &target,
-                cmd.path
-                    .as_os_str()
-                    .to_str()
-                    .ok_or_else(|| anyhow::anyhow!("non unicode path to interpreter"))?,
-            )
-            .context("could not register interpreter")?;
-        }
-    }
+    let target_version = register_toolchain(&cmd.path, cmd.name.as_deref())?;
     println!("Registered {} as {}", cmd.path.display(), target_version);
-
     Ok(())
 }
 
@@ -190,4 +133,66 @@ fn list(cmd: ListCommand) -> Result<(), Error> {
         }
     }
     Ok(())
+}
+
+pub fn register_toolchain(path: &Path, name: Option<&str>) -> Result<PythonVersion, Error> {
+    let output = Command::new(path)
+        .arg("-c")
+        .arg(INSPECT_SCRIPT)
+        .output()
+        .context("error executing interpreter to inspect version")?;
+    if !output.status.success() {
+        bail!("passed path does not appear to be a valid Python installation");
+    }
+
+    let info: InspectInfo = serde_json::from_slice(&output.stdout)
+        .context("could not parse interpreter output as json")?;
+    let target_version = match name {
+        Some(ref name) => format!("{}@{}", name, info.python_version),
+        None => {
+            format!(
+                "{}{}@{}",
+                info.python_implementation.to_ascii_lowercase(),
+                if info.python_debug { "-dbg" } else { "" },
+                info.python_version
+            )
+        }
+    };
+    let target_version: PythonVersion = target_version.parse()?;
+    let target = get_canonical_py_path(&target_version)?;
+
+    if target.is_file() || target.is_dir() {
+        bail!("target Python path {} is already in use", target.display());
+    }
+
+    // for the unlikely case that no python installation has been bootstrapped yet
+    if let Some(parent) = target.parent() {
+        fs::create_dir_all(parent).ok();
+    }
+
+    // on unix we always create a symlink
+    #[cfg(unix)]
+    {
+        symlink_file(path, target).context("could not symlink interpreter")?;
+    }
+
+    // on windows on the other hand we try a symlink first, but if that fails we fall back
+    // to writing the interpreter into the text file.  This is also supported by the
+    // interpreter lookup (see: get_toolchain_python_bin).  This is done because symlinks
+    // require higher privileges.
+    #[cfg(windows)]
+    {
+        if symlink_file(path, &target).is_err() {
+            fs::write(
+                &target,
+                cmd.path
+                    .as_os_str()
+                    .to_str()
+                    .ok_or_else(|| anyhow::anyhow!("non unicode path to interpreter"))?,
+            )
+            .context("could not register interpreter")?;
+        }
+    }
+
+    Ok(target_version)
 }

--- a/rye/src/sources.rs
+++ b/rye/src/sources.rs
@@ -220,7 +220,7 @@ impl fmt::Display for PythonVersionRequest {
     }
 }
 
-fn matches_version(req: &PythonVersionRequest, v: &PythonVersion) -> bool {
+pub fn matches_version(req: &PythonVersionRequest, v: &PythonVersion) -> bool {
     if req.kind.as_deref().unwrap_or(DEFAULT_KIND) != v.kind {
         return false;
     }

--- a/rye/src/sources.rs
+++ b/rye/src/sources.rs
@@ -220,7 +220,7 @@ impl fmt::Display for PythonVersionRequest {
     }
 }
 
-pub fn matches_version(req: &PythonVersionRequest, v: &PythonVersion) -> bool {
+fn matches_version(req: &PythonVersionRequest, v: &PythonVersion) -> bool {
     if req.kind.as_deref().unwrap_or(DEFAULT_KIND) != v.kind {
         return false;
     }

--- a/rye/src/sync.rs
+++ b/rye/src/sync.rs
@@ -203,8 +203,11 @@ pub fn sync(cmd: SyncOptions) -> Result<(), Error> {
                 eprintln!("Installing dependencies");
             }
             let tempdir = tempdir()?;
-            symlink_dir(get_pip_module(&self_venv), tempdir.path().join("pip"))
-                .context("failed linking pip module into for pip-sync")?;
+            symlink_dir(
+                get_pip_module(&self_venv).context("could not locate pip")?,
+                tempdir.path().join("pip"),
+            )
+            .context("failed linking pip module into for pip-sync")?;
             let mut pip_sync_cmd = Command::new(get_pip_sync(&py_ver, output)?);
             let root = pyproject.workspace_path();
 


### PR DESCRIPTION
Hello,

I really *love* rye's user XP. This is *so* refreshing...

This patch:

 * make `matches_version()` public.
 * add `ensure_toolchain(&PythonVersionRequest)`.
 * allow using preregistered toolchains for rye's self environments.

This is very useful in places where downloading a python build from random other places is a no no, because fighting corporate proxies & firewalls to get job done is no fun (hello zscaler).

Oh, also, as a bonus, this adds an option `--dbg` to `toolchain register` command`:
```
rye toolchain register --dbg /path/to/your/python/with/debug/symbols
```
Regards,
Charbel 