### PR TITLE
Add -dbg to the toolchain name for debug builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ that were not yet released.
 
 _Unreleased_
 
+- When a Python debug build (`Py_DEBUG`) is registered as custom toolchain,
+  `-dbg` is automatically appended to the name by default.  #269
+
 - lto+pgo builds are now preferred for the Python toolchain builds when
   available.  #268
 

--- a/docs/guide/toolchains/index.md
+++ b/docs/guide/toolchains/index.md
@@ -78,9 +78,11 @@ command.
 rye toolchain register /path/to/python
 ```
 
-The name of the toolchain is picked based on the interpreter.  For instance linking a regular
-cpython installation will be called `cpython@version`, whereas linking pypy would show up as
-`pypy@version`.  To override the name you can pass `--name`:
+The name of the toolchain is picked based on the interpreter.  For instance
+linking a regular cpython installation will be called `cpython@version`, whereas
+linking pypy would show up as `pypy@version`.  From Rye 0.5.0 onwards `-dbg` is
+appended to the name of the toolchain if it's a debug build.  To override the
+name you can pass `--name`:
 
 ```
 rye toolchain register --name=custom /path/to/python

--- a/rye/src/cli/toolchain.rs
+++ b/rye/src/cli/toolchain.rs
@@ -17,9 +17,11 @@ use crate::utils::symlink_file;
 const INSPECT_SCRIPT: &str = r#"
 import json
 import platform
+import sysconfig
 print(json.dumps({
     "python_implementation": platform.python_implementation(),
     "python_version": platform.python_version(),
+    "python_debug": bool(sysconfig.get_config_var('Py_DEBUG')),
 }))
 "#;
 
@@ -27,6 +29,7 @@ print(json.dumps({
 struct InspectInfo {
     python_implementation: String,
     python_version: String,
+    python_debug: bool,
 }
 
 /// Helper utility to manage Python toolchains.
@@ -98,8 +101,9 @@ fn register(cmd: RegisterCommand) -> Result<(), Error> {
         Some(ref name) => format!("{}@{}", name, info.python_version),
         None => {
             format!(
-                "{}@{}",
+                "{}{}@{}",
                 info.python_implementation.to_ascii_lowercase(),
+                if info.python_debug { "-dbg" } else { "" },
                 info.python_version
             )
         }


### PR DESCRIPTION
A take on a part of #267. If a debug build is registered, the name is automatically adjusted.