### PR TITLE
Support version command for rye

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ that were not yet released.
 
 _Unreleased_
 
+- Add `version` subcommand for rye. #285
+
 - Calling `rye init` on the root directory no longer fails.  #274
 
 <!-- released start -->

--- a/rye/src/cli/mod.rs
+++ b/rye/src/cli/mod.rs
@@ -22,6 +22,7 @@ mod sync;
 mod toolchain;
 mod tools;
 mod uninstall;
+mod version;
 
 use git_testament::git_testament;
 
@@ -61,6 +62,7 @@ enum Command {
     #[command(name = "self")]
     Rye(rye::Args),
     Uninstall(uninstall::Args),
+    Version(version::Args),
 }
 
 pub fn execute() -> Result<(), Error> {
@@ -106,6 +108,7 @@ pub fn execute() -> Result<(), Error> {
         Command::Tools(cmd) => tools::execute(cmd),
         Command::Rye(cmd) => rye::execute(cmd),
         Command::Uninstall(cmd) => uninstall::execute(cmd),
+        Command::Version(cmd) => version::execute(cmd),
     }
 }
 

--- a/rye/src/cli/version.rs
+++ b/rye/src/cli/version.rs
@@ -1,0 +1,32 @@
+use std::str::FromStr;
+
+use anyhow::{anyhow, Error};
+use clap::Parser;
+use pep440_rs::Version;
+
+use crate::pyproject::PyProject;
+
+/// Get or set project version
+#[derive(Parser, Debug)]
+pub struct Args {
+    /// The version to set
+    version: Option<String>,
+}
+
+pub fn execute(cmd: Args) -> Result<(), Error> {
+    let mut pyproject_toml = PyProject::discover()?;
+    match cmd.version {
+        Some(version) => {
+            let version =
+                Version::from_str(&version).map_err(|msg| anyhow!("invalid version: {}", msg))?;
+            pyproject_toml.set_version(&version);
+            pyproject_toml.save()?;
+
+            eprintln!("version set to {}.", version.to_string());
+        }
+        None => {
+            eprintln!("{}", pyproject_toml.version()?);
+        }
+    }
+    Ok(())
+}

--- a/rye/src/cli/version.rs
+++ b/rye/src/cli/version.rs
@@ -22,7 +22,7 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
             pyproject_toml.set_version(&version);
             pyproject_toml.save()?;
 
-            eprintln!("version set to {}.", version.to_string());
+            eprintln!("version set to {}", version);
         }
         None => {
             eprintln!("{}", pyproject_toml.version()?);


### PR DESCRIPTION
closes https://github.com/mitsuhiko/rye/issues/285

```
➜  o git:(main) ✗ rye version
0.1.0
➜  o git:(main) ✗ rye version 0.2.0
version set to 0.2.0

```