### PR TITLE
Run pip in workspace root (#284)

### DIFF
--- a/rye/src/lock.rs
+++ b/rye/src/lock.rs
@@ -329,6 +329,7 @@ fn generate_lockfile(
         .arg("-o")
         .arg(&requirements_file)
         .arg(requirements_file_in)
+        .current_dir(workspace_path)
         .env("PYTHONWARNINGS", "ignore");
     if output == CommandOutput::Verbose {
         cmd.arg("--verbose");


### PR DESCRIPTION
pip currently is excuted in the working directory of rye.  This means that pip cannot find the appropriate pyproject and will fail to write the requirements.lock. We now explicitly call pip in the determined workspace_path.

Please note this is an early PR and my first change. I don't fully understand the rye codebase yet and have not extensively tested this change yet. So beware, there might be dragons.

## Testing
Currently this has been tested doing the following:

```
$ rye init root
success: Initialized project in /home/dsp/src/root
  Run `rye sync` to get started
$ cd root
$ rye init submodule
success: Initialized project in /home/dsp/src/root/submodule
  Run `rye sync` to get started
$ echo "[tool.rye.workspace]\nmembers=[\"submodule\"]" >> pyproject.toml
$ cd submodule
$ rye sync
```

### Before this change
```
Generating production lockfile: /Users/dsp/src/rye/rye-test/requirements.lock
Traceback (most recent call last):
  File "/home/dsp/.rye/pip-tools/cpython@3.11/bin/pip-compile", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "/home/dsp/.rye/pip-tools/cpython@3.11/lib/python3.11/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dsp/.rye/pip-tools/cpython@3.11/lib/python3.11/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
...
pip._internal.exceptions.InstallationError: file:///submodule (from -r /var/folders/yl/jkvwmym95_sgrmcx_nmn21000000gn/T/.tmpGOZrJH (line 1)) does not appear to be a Python project: neither 'setup.py' nor 'pyproject.toml' found.
Error: could not write production lockfile for workspace
```
### After this change
```
Generating production lockfile: /home/dsp/src/root/requirements.lock
Generating dev lockfile: /home/dsp/src/root/requirements-dev.lock
Installing dependencies
Looking in indexes: https://pypi.org/simple/
Obtaining file:///. (from -r /var/folders/yl/jkvwmym95_sgrmcx_nmn21000000gn/T/tmp_zayqwfo (line 1))
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... done
  Preparing editable metadata (pyproject.toml) ... done
Obtaining file:///submodule (from -r /var/folders/yl/jkvwmym95_sgrmcx_nmn21000000gn/T/tmp_zayqwfo (line 2))
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... done
  Preparing editable metadata (pyproject.toml) ... done
Building wheels for collected packages: root, submodule
  Building editable for root (pyproject.toml) ... done
  Created wheel for root: filename=root-0.1.0-py3-none-any.whl size=994 sha256=c3d665d5a85c414f3963c4eddc9c141bec42689133c127c3265e5e28f9f5c38d
  Stored in directory: /private/var/folders/yl/jkvwmym95_sgrmcx_nmn21000000gn/T/pip-ephem-wheel-cache-1x_8h2fi/wheels/97/54/f5/d849319cdfa096e074df352654ee2e7c919da8951f090690c6
  Building editable for submodule (pyproject.toml) ... done
  Created wheel for submodule: filename=submodule-0.1.0-py3-none-any.whl size=1056 sha256=81643b6ab37c8be2e102259034e1dca0f46eba764b1980dcb93599994e15dd78
  Stored in directory: /private/var/folders/yl/jkvwmym95_sgrmcx_nmn21000000gn/T/pip-ephem-wheel-cache-1x_8h2fi/wheels/24/6f/3c/0d52b0234f153b8aa3f922419ed47c4c9cc62a221afb196f10
Successfully built root submodule
Installing collected packages: submodule, root
Successfully installed root-0.1.0 submodule-0.1.0
Done!
```