### PR TITLE
sync, lock: --pyproject argument

### DIFF
--- a/rye/src/cli/lock.rs
+++ b/rye/src/cli/lock.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use anyhow::Error;
 use clap::Parser;
 
@@ -29,6 +31,9 @@ pub struct Args {
     /// Enables all features.
     #[arg(long)]
     all_features: bool,
+    /// Use this pyproject.toml file
+    #[arg(long, value_name = "PYPROJECT_TOML")]
+    pyproject: Option<PathBuf>,
 }
 
 pub fn execute(cmd: Args) -> Result<(), Error> {
@@ -43,6 +48,7 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
             features: cmd.features,
             all_features: cmd.all_features,
         },
+        pyproject: cmd.pyproject,
         ..SyncOptions::default()
     })?;
     Ok(())

--- a/rye/src/cli/sync.rs
+++ b/rye/src/cli/sync.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use anyhow::Error;
 use clap::Parser;
 
@@ -38,6 +40,9 @@ pub struct Args {
     /// Enables all features.
     #[arg(long)]
     all_features: bool,
+    /// Use this pyproject.toml file
+    #[arg(long, value_name = "PYPROJECT_TOML")]
+    pyproject: Option<PathBuf>,
 }
 
 pub fn execute(cmd: Args) -> Result<(), Error> {
@@ -59,7 +64,7 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
             features: cmd.features,
             all_features: cmd.all_features,
         },
-        pyproject: None,
+        pyproject: cmd.pyproject,
     })?;
     Ok(())
 }

--- a/rye/src/sync.rs
+++ b/rye/src/sync.rs
@@ -81,9 +81,12 @@ pub fn sync(cmd: SyncOptions) -> Result<(), Error> {
     let py_ver = pyproject.venv_python_version()?;
     let output = cmd.output;
 
-    // check conflicting options
-    if cmd.pyproject.is_some() && cmd.mode != SyncMode::PythonOnly {
-        bail!("pypyroject location: only implemented for PythonOnly sync");
+    if cmd.pyproject.is_some()
+        && cmd.mode != SyncMode::PythonOnly
+        && !pyproject.toml_path().ends_with("pyproject.toml")
+    {
+        // pip-tools will search for pyproject.toml
+        bail!("cannot sync or generate lockfile: package needs 'pyproject.toml'");
     }
 
     // ensure we are bootstrapped


### PR DESCRIPTION
Add the --pyproject argument for rye sync and rye lock.

Sync, lock will only work if the file is literally called pyproject.toml in the filename, because that's what pip-tools expect. Further meditation over this maybe makes any other name than `pyproject.toml` unnatural, most tools are quite insistent that this is the only valid name (?). If rye would have the same opinion, then we could consider changing all these arguments to `--project <directory>` instead.