### PR TITLE
Add --clean for build command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ that were not yet released.
 
 _Unreleased_
 
+- Add `--clean` for `build` command.  #297
+
 - Fixed an issue where pip was not invoked from the right working directory
   causing issues for workspace installations.  #292
 

--- a/rye/src/cli/build.rs
+++ b/rye/src/cli/build.rs
@@ -1,3 +1,4 @@
+use std::fs;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
@@ -30,6 +31,9 @@ pub struct Args {
     /// Use this pyproject.toml file
     #[arg(long, value_name = "PYPROJECT_TOML")]
     pyproject: Option<PathBuf>,
+    /// Clean the output directory first
+    #[arg(short, long)]
+    clean: bool,
     /// Enables verbose diagnostics.
     #[arg(short, long)]
     verbose: bool,
@@ -47,6 +51,15 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
         Some(path) => path,
         None => project.workspace_path().join("dist"),
     };
+
+    if cmd.clean {
+        for entry in fs::read_dir(&out)? {
+            let path = entry?.path();
+            if path.is_file() {
+                fs::remove_file(path)?;
+            }
+        }
+    }
 
     let mut projects = Vec::new();
 


### PR DESCRIPTION
It would be useful to add a `clean` parameter to the `build` command if I just need the current latest build target.