### PR TITLE
Add --bump for version command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ that were not yet released.
 
 _Unreleased_
 
+- `rye version` can bump version by `--bump` option now.  #298
+
 - Add `--clean` for `build` command.  #297
 
 - Fixed an issue where pip was not invoked from the right working directory

--- a/rye/src/cli/version.rs
+++ b/rye/src/cli/version.rs
@@ -57,7 +57,7 @@ fn bump_version(version: &mut Version, bump: &str, pyproject: &mut PyProject) {
         }
     }
 
-    pyproject.set_version(&version);
+    pyproject.set_version(version);
     pyproject.save().unwrap();
 
     eprintln!("version bumped to {}", version);

--- a/rye/src/cli/version.rs
+++ b/rye/src/cli/version.rs
@@ -56,7 +56,11 @@ fn bump_version(version: &mut Version, bump: Bump, pyproject: &mut PyProject) ->
             style("warning:").red()
         );
     } else {
-        version.release[bump as usize] += 1;
+        let index = bump as usize;
+        if version.release.get(index).is_none() {
+            version.release.resize(index + 1, 0);
+        }
+        version.release[index] += 1;
     }
 
     pyproject.set_version(version);

--- a/rye/src/cli/version.rs
+++ b/rye/src/cli/version.rs
@@ -1,17 +1,17 @@
 use std::str::FromStr;
 
+use crate::pyproject::PyProject;
 use anyhow::{anyhow, Error};
 use clap::Parser;
+use console::style;
 use pep440_rs::Version;
-
-use crate::pyproject::PyProject;
 
 /// Get or set project version
 #[derive(Parser, Debug)]
 pub struct Args {
     /// The version to set
     version: Option<String>,
-    /// The version bump to apply
+    /// The version bump to apply [major, minor, patch]
     #[arg(short, long)]
     bump: Option<String>,
 }
@@ -29,27 +29,36 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
         }
         None => {
             let mut version = pyproject_toml.version()?;
-            if let Some(bump) = cmd.bump {
-                let bumped = bump_version(&mut version, &bump);
-                pyproject_toml.set_version(&version);
-                pyproject_toml.save()?;
-                if bumped {
-                    eprintln!("version bumped to {}", version);
-                }
-            } else {
-                eprintln!("{}", version);
+            match cmd.bump {
+                Some(bump) => bump_version(&mut version, &bump, &mut pyproject_toml),
+                None => eprintln!("{}", version),
             }
         }
     }
     Ok(())
 }
 
-fn bump_version(version: &mut Version, bump: &str) -> bool {
-    match bump {
-        "major" => version.release[0] += 1,
-        "minor" => version.release[1] += 1,
-        "patch" => version.release[2] += 1,
-        _ => return false,
+fn bump_version(version: &mut Version, bump: &str, pyproject: &mut PyProject) {
+    if version.is_post() {
+        version.post = None;
     }
-    true
+    if version.is_dev() {
+        version.dev = None;
+        eprintln!(
+            "{} dev version will be bumped to release version",
+            style("warning:").red()
+        );
+    } else {
+        match bump {
+            "major" => version.release[0] += 1,
+            "minor" => version.release[1] += 1,
+            "patch" => version.release[2] += 1,
+            _ => return,
+        }
+    }
+
+    pyproject.set_version(&version);
+    pyproject.save().unwrap();
+
+    eprintln!("version bumped to {}", version);
 }


### PR DESCRIPTION
https://github.com/mitsuhiko/rye/issues/285

```
➜  o git:(main) ✗ rye version
0.1.0
➜  o git:(main) ✗ rye version 0.2.0
version set to 0.2.0
➜  o git:(main) ✗ rye version --bump major
version bumped to 1.2.0
➜  o git:(main) ✗ rye version --bump minor
version bumped to 1.3.0
➜  o git:(main) ✗ rye version --bump patch
version bumped to 1.3.1
➜  o git:(main) ✗ rye version --bump ooo
```