### PR TITLE
workspace is member: fix relative path

### DIFF
--- a/rye/src/pyproject.rs
+++ b/rye/src/pyproject.rs
@@ -349,8 +349,7 @@ impl Workspace {
 
     /// Checks if a project is a member of the declared workspace.
     pub fn is_member(&self, path: &Path) -> bool {
-        let canonicalized = self.root.join(path);
-        if let Ok(relative) = path.strip_prefix(canonicalized) {
+        if let Ok(relative) = path.strip_prefix(&self.root) {
             if relative == Path::new("") || self.members.is_empty() {
                 true
             } else {


### PR DESCRIPTION
It looks to me like the relative path is always empty. I'm not 100% sure what the intention was here with the canonicalization.

With this fix, limiting members using an explicit list in the workspace should work better. Previously it seemed to include everything in all cases.

rye show is the quickest way to see the workspace member list, but it affects rye lock foremost (with bad effects if it includes stray projects.)


Reproduce:

```shell
rye init workspace
cd workspace
echo "[tool.rye.workspace]" >> pyproject.toml
echo 'members = ["a"]' >> pyproject.toml
rye init a
rye init b
rye show
```

Expected: Workspace is root and a. Actual: Workspace was root, a, and b.