### PR TITLE
Add cli description

### DIFF
--- a/rye/src/cli/mod.rs
+++ b/rye/src/cli/mod.rs
@@ -31,6 +31,7 @@ use crate::platform::symlinks_supported;
 
 git_testament!(TESTAMENT);
 
+/// An Experimental Package Management Solution for Python
 #[derive(Parser, Debug)]
 #[command(arg_required_else_help = true)]
 struct Args {


### PR DESCRIPTION
```
➜  ~ rye -h
An Experimental Package Management Solution for Python

Usage: rye [COMMAND]

Commands:
  add        Adds a Python package to this project

```