### PR TITLE
Set PROJECT_ROOT like pdm expects

### DIFF
--- a/rye/src/lock.rs
+++ b/rye/src/lock.rs
@@ -330,7 +330,8 @@ fn generate_lockfile(
         .arg(&requirements_file)
         .arg(requirements_file_in)
         .current_dir(workspace_path)
-        .env("PYTHONWARNINGS", "ignore");
+        .env("PYTHONWARNINGS", "ignore")
+        .env("PROJECT_ROOT", make_project_root_fragment(workspace_path));
     if output == CommandOutput::Verbose {
         cmd.arg("--verbose");
     } else {
@@ -407,6 +408,16 @@ fn finalize_lockfile(
         writeln!(rv, "{}", line)?;
     }
     Ok(())
+}
+
+pub fn make_project_root_fragment(root: &Path) -> String {
+    // XXX: ${PROJECT_ROOT} is supposed to be used in the context of file:///
+    // so let's make sure it is url escaped.  This is pretty hacky but
+    // good enough for now.
+    // No leading slash to fit with file:///${PROJECT_ROOT} convention
+    root.to_string_lossy()
+        .trim_start_matches('/')
+        .replace(' ', "%20")
 }
 
 fn make_relative_url(path: &Path, base: &Path) -> Result<String, Error> {

--- a/rye/src/sync.rs
+++ b/rye/src/sync.rs
@@ -10,7 +10,8 @@ use tempfile::tempdir;
 use crate::bootstrap::{ensure_self_venv, fetch, get_pip_module};
 use crate::consts::VENV_BIN;
 use crate::lock::{
-    update_single_project_lockfile, update_workspace_lockfile, LockMode, LockOptions,
+    make_project_root_fragment, update_single_project_lockfile, update_workspace_lockfile,
+    LockMode, LockOptions,
 };
 use crate::piptools::get_pip_sync;
 use crate::platform::get_toolchain_python_bin;
@@ -229,10 +230,7 @@ pub fn sync(cmd: SyncOptions) -> Result<(), Error> {
             let py_path = get_venv_python_bin(&venv);
 
             pip_sync_cmd
-                // XXX: ${PROJECT_ROOT} is supposed to be used in the context of file:///
-                // so let's make sure it is url escaped.  This is pretty hacky but
-                // good enough for now.
-                .env("PROJECT_ROOT", root.to_string_lossy().replace(' ', "%2F"))
+                .env("PROJECT_ROOT", make_project_root_fragment(&root))
                 .env("PYTHONPATH", tempdir.path())
                 .current_dir(&root)
                 .arg("--python-executable")


### PR DESCRIPTION
Set PROJECT_ROOT as env variable both for pip-compile and pip-sync. pdm does the equivalent of not using any leading slash in its replacement (We could see that `file:////` triggered an error(!)).

If PROJECT_ROOT is set like this, relative paths inside and outside of the project work :slightly_smiling_face: 

Here's how to setup the project:

```shell
#!/bin/sh

# project_root needs to use pdm for relative paths.
rye init sibling
rye init project_root --build-system pdm
cd project_root
rye init lib/a
rye init lib/b --build-system pdm

rye add --path ../sibling sibling
rye add --path ./lib/a a
rye add --path ./lib/b b
```
With this PR we can successfully `cd project_root; rye sync -v` 

The pyproject ends up with these dependencies for reference:

```toml
dependencies = [
    "sibling @ file:///${PROJECT_ROOT}/../sibling",
    "a @ file:///${PROJECT_ROOT}/lib/a",
    "b @ file:///${PROJECT_ROOT}/lib/b",
]
```

With `rye 0.7.0` the project will not sync (try inside project_root). With this PR, it will.

However - note that if "a", "b" are workspace members and also path dependencies, it will not work happily - it will not see that "lib/a" and its absolute path equivalent are the same thing.

Endnote: I don't think PDM actually sets this environment variable, it just parses it in some other ad hoc way.
Tested on linux.