### PR TITLE
Make rye add pick == instead of ~= for single component versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ that were not yet released.
 
 _Unreleased_
 
+- `rye add` now pins versions with `==` instead of `~=` when the version of the
+  package does not use at least two components.  This means that for instance it
+  will now correctly use `openai-whisper==20230314` rather than
+  `openai-whisper~=20230314` which is not actually satisfiable.  #328
+
 - `rye install` now lets you install dependencies into the tool's virtualenv
   during installation that are undeclared via the new `--extra-requirement`
   option.  #326

--- a/rye/src/cli/add.rs
+++ b/rye/src/cli/add.rs
@@ -285,7 +285,9 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
                 requirement.version_or_url = Some(VersionOrUrl::VersionSpecifier(
                     VersionSpecifiers::from_iter(Some(
                         VersionSpecifier::new(
-                            if version.is_local() {
+                            // local versions or versions with only one component cannot
+                            // use ~= but need to use ==.
+                            if version.is_local() || version.release.len() < 2 {
                                 Operator::Equal
                             } else {
                                 Operator::TildeEqual


### PR DESCRIPTION
This fixes `rye add openai-whisper`.