### PR TITLE
workspace: ignore .-directories when searching for projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,11 @@ _Unreleased_
   during installation that are undeclared via the new `--extra-requirement`
   option.  #326
 
-- Improved handling of relative path installations by setting `PROJECT_PATH`
+- Improved handling of relative path installations by setting `PROJECT_ROOT`
   the same way as PDM does.  #321
+
+- Workspaces will now never discover `pyproject.toml` files in any dot
+  directories. (Name starting with `.`)  #329
 
 - Fixed `rye build` not working correctly on Windows.  #327
 

--- a/rye/src/pyproject.rs
+++ b/rye/src/pyproject.rs
@@ -442,7 +442,8 @@ impl Workspace {
 
 /// Check if recurse should be skipped into directory with this name
 fn skip_recurse_into(name: &OsStr) -> bool {
-    return name == OsStr::new(".venv") || name == OsStr::new(".git");
+    // We want to ignore hidden directories: .venv, .git, and others.
+    name.to_str().map(|s| s.starts_with('.')).unwrap_or(false)
 }
 
 /// Could not auto-discover any pyproject


### PR DESCRIPTION
Prompted by finding .pdm-build which contain pyproject.toml files
after building a wheel.
