### PR TITLE
Add support for global, non venv Python invocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@ _Unreleased_
 - Added support for the new `behavior.global-python` flag which turns on global
   Python shimming.  When enabled then the `python` shim works even outside of
   Rye managed projects.  Additionally the shim (when run outside of Rye managed
-  projects) supports a special first paramter `+VERSION` which requests a
+  projects) supports a special first parameter `+VERSION` which requests a
   specific version of Python (eg: `python +3.8` to request Python 3.8).  #336
+
+<!-- released start -->
 
 ## 0.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ that were not yet released.
 
 _Unreleased_
 
-<!-- released start -->
+- Added support for the new `behavior.global-python` flag which turns on global
+  Python shimming.  When enabled then the `python` shim works even outside of
+  Rye managed projects.  Additionally the shim (when run outside of Rye managed
+  projects) supports a special first paramter `+VERSION` which requests a
+  specific version of Python (eg: `python +3.8` to request Python 3.8).  #336
 
 ## 0.8.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1530,7 +1530,7 @@ dependencies = [
 
 [[package]]
 name = "rye"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "age",
  "anyhow",

--- a/docs/guide/config.md
+++ b/docs/guide/config.md
@@ -72,6 +72,9 @@ https = "http://127.0.0.1:4000"
 # When set to true the `managed` flag is always assumed to be true.
 force_rye_managed = false
 
+# Enables global shims when set to `true`
+global-python = false
+
 # a array of tables with optional sources.  Same format as in pyproject.toml
 [[sources]]
 name = "default"

--- a/docs/guide/config.md
+++ b/docs/guide/config.md
@@ -72,7 +72,9 @@ https = "http://127.0.0.1:4000"
 # When set to true the `managed` flag is always assumed to be true.
 force_rye_managed = false
 
-# Enables global shims when set to `true`
+# Enables global shims when set to `true`.  This means that the installed
+# `python` shim will resolve to a Rye managed toolchain even outside of
+# virtual environments.
 global-python = false
 
 # a array of tables with optional sources.  Same format as in pyproject.toml

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -94,6 +94,9 @@ interpreter.
 
     Note that you might need to restart your login session for this to take effect.
 
+There is a quite a bit to shims and their behavior.  Make sure to [read up on shims](shims.md)
+to learn more.
+
 ## Updating Rye
 
 To update rye to the latest version you can use `rye` itself:

--- a/docs/guide/shims.md
+++ b/docs/guide/shims.md
@@ -1,0 +1,43 @@
+# Shims
+
+After installation Rye places two shims on your `PATH`: `python` and `python3`.  These
+shims have specific behavior that changes depending on if they are used within a Rye
+managed project or outside.
+
+Inside a Rye managed project the resolve to the Python interpreter of the virtualenv.
+This means that even if you do not enable the virtualenv, you can just run `python`
+in a shell, and it will automatically operate in the right environment.
+
+Outside a Rye managed project it typically resolves to your system Python, though you
+can also opt to have it resolve to a Rye managed Python installation for you.  This is
+done so that it's not disruptive to your existing workflows which might depend on the
+System python installation.
+
+## Global Shims
+
++++ 0.9.0
+
+To enable global shims, you need to enable the `global-python` flag in
+the [`config.toml`](config.md) file:
+
+```toml
+[behavior]
+global-python = true
+```
+
+Afterwards if you run `python` outside of a Rye managed project it will
+spawn a Python interpreter that is shipped with Rye.  It will honor the
+closest `.python-version` file for you.  Additionally you can also
+explicitly request a specific Python version by adding `+VERSION` after
+the `python` command.  For instance this runs a script with Python 3.8:
+
+```bash
+python +3.8 my-script.py
+```
+
+!!! Note
+
+    Selecting a specific Python version this way only works outside of
+    Rye managed projects.  Within Rye managed projects, the version needs
+    to be explicitly selected via `.python-version` or with the
+    `requires-python` key in `pyproject.toml`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,7 @@ nav:
     - Installation: guide/installation.md
     - Basics: guide/basics.md
     - Configuration: guide/config.md
+    - Shims: guide/shims.md
     - Python Project: guide/pyproject.md
     - Syncing and Locking: guide/sync.md
     - Building and Publishing: guide/publish.md

--- a/rye/src/cli/shim.rs
+++ b/rye/src/cli/shim.rs
@@ -1,15 +1,19 @@
 use std::convert::Infallible;
 use std::env;
 use std::ffi::{OsStr, OsString};
+use std::str::FromStr;
 
-use anyhow::{bail, Context, Error};
+use anyhow::{anyhow, bail, Context, Error};
 use same_file::is_same_file;
 use std::process::Command;
 use which::which_in_global;
 
 use crate::bootstrap::{ensure_self_venv, get_pip_runner};
+use crate::config::Config;
 use crate::consts::VENV_BIN;
-use crate::pyproject::PyProject;
+use crate::platform::{get_python_version_request_from_pyenv_pin, get_toolchain_python_bin};
+use crate::pyproject::{latest_available_python_version, PyProject};
+use crate::sources::{PythonVersion, PythonVersionRequest};
 use crate::sync::{sync, SyncOptions};
 use crate::utils::{exec_spawn, get_venv_python_bin, CommandOutput};
 
@@ -100,6 +104,47 @@ fn get_shim_target(target: &str, args: &[OsString]) -> Result<Option<Vec<OsStrin
         // secret pip shims
         if target == "pip" || target == "pip3" {
             return Ok(Some(get_pip_shim(&pyproject, args, CommandOutput::Normal)?));
+        }
+    } else if target == "python" || target == "python3" {
+        let config = Config::current();
+        if config.global_python() {
+            let mut args = args.to_vec();
+            let mut remove1 = false;
+
+            let version_request = if let Some(rest) = args
+                .get(1)
+                .and_then(|x| x.as_os_str().to_str())
+                .and_then(|x| x.strip_prefix('+'))
+            {
+                remove1 = true;
+                PythonVersionRequest::from_str(rest)
+                    .context("invalid python version requested from command line")?
+            } else {
+                match get_python_version_request_from_pyenv_pin(&std::env::current_exe()?) {
+                    Some(version_request) => version_request,
+                    None => config.default_toolchain()?,
+                }
+            };
+
+            let py_ver = match PythonVersion::try_from(version_request.clone()) {
+                Ok(py_ver) => py_ver,
+                Err(_) => latest_available_python_version(&version_request)
+                    .ok_or_else(|| anyhow!("Unable to determine target Python version"))?,
+            };
+            let py = get_toolchain_python_bin(&py_ver)?;
+            if !py.is_file() {
+                bail!(
+                    "Requested Python version ({}) is not installed. Install with `rye fetch {}`",
+                    py_ver,
+                    py_ver
+                );
+            }
+
+            args[0] = py.into();
+            if remove1 {
+                args.remove(1);
+            }
+            return Ok(Some(args));
         }
     }
 

--- a/rye/src/config.rs
+++ b/rye/src/config.rs
@@ -126,6 +126,15 @@ impl Config {
             })
     }
 
+    /// Allow rye shims to resolve globally installed Pythons.
+    pub fn global_python(&self) -> bool {
+        self.doc
+            .get("behavior")
+            .and_then(|x| x.get("global-python"))
+            .and_then(|x| x.as_bool())
+            .unwrap_or(false)
+    }
+
     /// Pretend that all projects are rye managed.
     pub fn force_rye_managed(&self) -> bool {
         self.doc


### PR DESCRIPTION
This adds support for invoking the `python` shim from outside of a rye managed virtualenv. This behavior is disabled by default but turned on by turning it on in the `config.toml`:

```toml
[behavior]
global-python = true
```

Then running `python` will pick up the `.python-version` defined Python or one that is sett in `default.toolchain` in the `config.toml`. Additionally it's possible run `python +3.8` to invoke a Python 3.8 interpreter on the spot.

Fixes #330