### PR TITLE
Fix broken global shims on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ that were not yet released.
 
 _Unreleased_
 
+- Fixed the global shim behavior on Windows.  #344
+
 <!-- released start -->
 
 ## 0.9.0


### PR DESCRIPTION
The global shim feature did not work properly on windows because the `.exe` extension was not correctly considered when the shim was intercepted in the lookup.