### PR TITLE
Fix argument conflicts_with in rye init

### DIFF
--- a/rye/src/cli/init.rs
+++ b/rye/src/cli/init.rs
@@ -62,10 +62,10 @@ pub struct Args {
     #[arg(long)]
     no_import: bool,
     /// Requirements files to initialize pyproject.toml with.
-    #[arg(short, long, name = "REQUIREMENTS_FILE", conflicts_with = "no-import")]
+    #[arg(short, long, name = "REQUIREMENTS_FILE", conflicts_with = "no_import")]
     requirements: Option<Vec<PathBuf>>,
     /// Development requirements files to initialize pyproject.toml with.
-    #[arg(long, name = "DEV_REQUIREMENTS_FILE", conflicts_with = "no-import")]
+    #[arg(long, name = "DEV_REQUIREMENTS_FILE", conflicts_with = "no_import")]
     dev_requirements: Option<Vec<PathBuf>>,
     /// Enables verbose diagnostics.
     #[arg(short, long)]


### PR DESCRIPTION
I found this error when running rye init:

Command init: Argument or group 'no-import' specified in 'conflicts_with*' for 'REQUIREMENTS_FILE' does not exist'

and this seems to address it.

This is how clap has specced it: https://github.com/clap-rs/clap/pull/4759#issuecomment-1466585442