### PR TITLE
rye add argument checking

### DIFF
--- a/rye/src/cli/add.rs
+++ b/rye/src/cli/add.rs
@@ -182,6 +182,7 @@ impl ReqExtras {
 #[derive(Parser, Debug)]
 pub struct Args {
     /// The package to add as PEP 508 requirement string. e.g. 'flask==2.2.3'
+    #[arg(required = true)]
     requirements: Vec<String>,
     #[command(flatten)]
     req_extras: ReqExtras,

--- a/rye/src/cli/add.rs
+++ b/rye/src/cli/add.rs
@@ -108,6 +108,12 @@ impl From<Pin> for Operator {
 }
 
 impl ReqExtras {
+    /// Return true if any path, url, features or similar are set
+    /// (anything specific for 1 requirement).
+    pub fn has_specifiers(&self) -> bool {
+        self.path.is_some() || self.url.is_some() || self.git.is_some() || !self.features.is_empty()
+    }
+
     pub fn force_absolute(&mut self) {
         self.absolute = true;
     }
@@ -234,6 +240,10 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
         Some(pin) => Operator::from(pin),
         None => Config::current().default_dependency_operator(),
     };
+
+    if cmd.req_extras.has_specifiers() && cmd.requirements.len() != 1 {
+        bail!("path/url/git/features is not compatible with passing multiple requirements: expected one requirement.")
+    }
 
     for str_requirement in cmd.requirements {
         let mut requirement = Requirement::from_str(&str_requirement)?;

--- a/rye/src/cli/remove.rs
+++ b/rye/src/cli/remove.rs
@@ -11,6 +11,7 @@ use crate::utils::{format_requirement, CommandOutput};
 #[derive(Parser, Debug)]
 pub struct Args {
     /// The packages to remove.
+    #[arg(required = true)]
     requirements: Vec<String>,
     /// Remove this from dev dependencies.
     #[arg(long)]


### PR DESCRIPTION
Without some restriction, `rye add --path foo` would previously run as a
successful command that does nothing, which is confusing for the user.
Always require >= 1 requirement in add and remove.

Don't allow `rye add --path ./x x y` or similar, these arguments make
sense with one requirement only.

I'm not sure if there is a nicer way of reporting argument errors here
than using `bail!()`.