### PR TITLE
Ensure python exists when find self venv

### DIFF
--- a/rye/src/platform.rs
+++ b/rye/src/platform.rs
@@ -159,6 +159,9 @@ pub fn list_known_toolchains() -> Result<Vec<(PythonVersion, PathBuf)>, Error> {
                 .parse::<PythonVersion>()
             {
                 let target = get_toolchain_python_bin(&ver)?;
+                if !target.exists() {
+                    continue
+                }
                 rv.push((ver, target));
             }
         }


### PR DESCRIPTION
Check if the python binary exists in `list_known_toolchains`. If not, skip it since it's not a valid python toolchain.

The main scenario related to this issue, is when you execute rye first time which will cause self bootstrap (like `ryn sync`), during the self toolchain download time (this may take a long time with an unstable internet connection), hit ctrl-c to break it, then rerun the command, then you will always got this error:

```
Bootstrapping rye internals
Found a compatible python version: cpython@3.11.3
error: could not sync because bootstrap failed

Caused by:
    0: unable to create self venv using /home/■■■■■/.rye/py/cpython@3.11.3/python3
    1: No such file or directory (os error 2)
```

This is caused by the `/home/■■■■■/.rye/py/cpython@3.11.3/` is created and is empty in the first run, and then the `ensure_self_toolchain` think it's a valid toolchain, and try to using python in it, then caused the error above.