### PR TITLE
Version command can show dynamic version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ that were not yet released.
 
 _Unreleased_
 
+- The `version` command can show dynamic versions now. #355
+
 - Fixed a bug with `rye init` not operating correctly due to a argument conflict.  #346
 
 - Scripts now support a PDM style `call` script type.  #345

--- a/rye/Cargo.toml
+++ b/rye/Cargo.toml
@@ -49,6 +49,7 @@ zip = { version = "0.6.5", features = ["deflate"], default-features = false }
 self-replace = "1.3.2"
 configparser = "3.0.2"
 monotrail-utils = { git = "https://github.com/konstin/poc-monotrail", version = "0.0.1" }
+python-pkginfo = { version = "0.5.6", features = ["serde"] }
 
 [target."cfg(windows)".dependencies]
 winapi = { version = "0.3.9", default-features = false, features = [] }

--- a/rye/src/cli/version.rs
+++ b/rye/src/cli/version.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use crate::pyproject::PyProject;
-use anyhow::{anyhow, Error};
+use anyhow::{anyhow, bail, Error};
 use clap::{Parser, ValueEnum};
 use pep440_rs::Version;
 
@@ -28,10 +28,18 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
         Some(version) => {
             let version =
                 Version::from_str(&version).map_err(|msg| anyhow!("invalid version: {}", msg))?;
-            pyproject_toml.set_version(&version);
-            pyproject_toml.save()?;
+            if pyproject_toml
+                .dynamic()
+                .unwrap()
+                .contains(&"version".to_string())
+            {
+                bail!("unsupport set dynamic version");
+            } else {
+                pyproject_toml.set_version(&version);
+                pyproject_toml.save()?;
 
-            echo!("version set to {}", version);
+                echo!("version set to {}", version);
+            }
         }
         None => {
             let mut version = pyproject_toml.version()?;

--- a/rye/src/cli/version.rs
+++ b/rye/src/cli/version.rs
@@ -33,7 +33,7 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
                 .unwrap()
                 .contains(&"version".to_string())
             {
-                bail!("unsupport set dynamic version");
+                bail!("unsupported set dynamic version");
             } else {
                 pyproject_toml.set_version(&version);
                 pyproject_toml.save()?;

--- a/rye/src/pyproject.rs
+++ b/rye/src/pyproject.rs
@@ -749,7 +749,7 @@ impl PyProject {
             .doc
             .get("project")
             .and_then(|x| x.get("version"))
-            .and_then(|x| Some(x.to_string()));
+            .map(|x| x.to_string());
         if let Some(dynamic) = self.dynamic() {
             if dynamic.contains(&"version".to_string()) {
                 if let Ok(metadata) = get_project_metadata(&self.root_path()) {


### PR DESCRIPTION
Can read version info when dynamic.

```
dynamic = ["version"]

[tool.hatch.version]
path="src/o/__init__.py"
```

Some tests:
```
➜  o git:(main) ✗ rye version
0.1.0

➜  o git:(main) ✗ rye version 0.2.0
error: unsupported set dynamic version

```
