### PR TITLE
Set prompt when create venv

### DIFF
--- a/rye/src/installer.rs
+++ b/rye/src/installer.rs
@@ -97,7 +97,13 @@ pub fn install(
     // make sure we have a compatible python version
     let py_ver = fetch(py_ver, output)?;
 
-    create_virtualenv(output, &self_venv, &py_ver, &target_venv_path)?;
+    create_virtualenv(
+        output,
+        &self_venv,
+        &py_ver,
+        &target_venv_path,
+        requirement.name.as_str(),
+    )?;
 
     let mut cmd = Command::new(self_venv.join(VENV_BIN).join("pip"));
     cmd.arg("--python")

--- a/rye/src/piptools.rs
+++ b/rye/src/piptools.rs
@@ -26,7 +26,7 @@ fn get_pip_tools_bin(py_ver: &PythonVersion, output: CommandOutput) -> Result<Pa
     if output != CommandOutput::Quiet {
         echo!("Creating virtualenv for pip-tools");
     }
-    create_virtualenv(output, &self_venv, py_ver, &venv)?;
+    create_virtualenv(output, &self_venv, py_ver, &venv, "pip-tools")?;
 
     let mut cmd = Command::new(self_venv.join(VENV_BIN).join("pip"));
     cmd.arg("--python")

--- a/rye/src/sync.rs
+++ b/rye/src/sync.rs
@@ -143,7 +143,8 @@ pub fn sync(cmd: SyncOptions) -> Result<(), Error> {
             );
             echo!("Python version: {}", style(&py_ver).cyan());
         }
-        create_virtualenv(output, &self_venv, &py_ver, &venv)
+        let prompt = pyproject.name().unwrap_or("venv");
+        create_virtualenv(output, &self_venv, &py_ver, &venv, prompt)
             .context("failed creating virtualenv ahead of sync")?;
         fs::write(
             venv.join("rye-venv.json"),
@@ -288,6 +289,7 @@ pub fn create_virtualenv(
     self_venv: &Path,
     py_ver: &PythonVersion,
     venv: &Path,
+    prompt: &str,
 ) -> Result<(), Error> {
     let py_bin = get_toolchain_python_bin(py_ver)?;
     let mut venv_cmd = Command::new(self_venv.join(VENV_BIN).join("virtualenv"));
@@ -300,6 +302,8 @@ pub fn create_virtualenv(
     venv_cmd.arg("-p");
     venv_cmd.arg(&py_bin);
     venv_cmd.arg("--no-seed");
+    venv_cmd.arg("--prompt");
+    venv_cmd.arg(prompt);
     venv_cmd.arg("--");
     venv_cmd.arg(venv);
     let status = venv_cmd


### PR DESCRIPTION
Specify prompt when create venv. The prompt is not used for `rye shell`, but it's usefull for using rye under an IDE like:

![prompt-in-vscode](https://github.com/mitsuhiko/rye/assets/699636/ccc9996e-740e-4f1f-8ade-36d680e0c102)
