### PR TITLE
Update `rye init --help` message

### DIFF
--- a/rye/src/cli/init.rs
+++ b/rye/src/cli/init.rs
@@ -29,7 +29,7 @@ use crate::utils::{
     CommandOutput, CopyDirOptions,
 };
 
-/// Creates a new python project.
+/// Initialize a new or existing Python project with Rye.
 #[derive(Parser, Debug)]
 pub struct Args {
     /// Where to place the project (defaults to current path)


### PR DESCRIPTION
Closes #400 

This is a minor change that attempts to disambiguate *creating* a new project from *initializing* one behind `rye init`.

FWIW `cargo init` and `cargo new` exist. I don't personally have an issue with one `rye init` command, so this PR attempts to preserve that merge by updating verbiage.