### PR TITLE
Improve author detection when includeIf is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ that were not yet released.
 
 _Unreleased_
 
+- The order of git submodule initialization was changed.  This improves the
+  automatic author detection when `includeIf` is used.  #443
+
 - The linux shim installer code will no longer fall back to symlinks when a
   hardlink cannot be created.  This is done as a symlinked shim will not
   ever function correctly on Linux.  This prevents the shim executables like

--- a/rye/src/cli/init.rs
+++ b/rye/src/cli/init.rs
@@ -483,7 +483,6 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
         }
     }
 
-
     echo!(
         "{} Initialized project in {}",
         style("success:").green(),

--- a/rye/src/platform.rs
+++ b/rye/src/platform.rs
@@ -173,6 +173,8 @@ pub fn list_known_toolchains() -> Result<Vec<(PythonVersion, PathBuf)>, Error> {
 /// Returns the default author from git or the config.
 pub fn get_default_author_with_fallback(dir: &PathBuf) -> Option<(String, String)> {
     let (mut name, mut email) = Config::current().default_author();
+    let is_name_none = name.is_none();
+    let is_email_none = email.is_none();
 
     if let Ok(rv) = Command::new("git")
         .arg("config")
@@ -184,10 +186,10 @@ pub fn get_default_author_with_fallback(dir: &PathBuf) -> Option<(String, String
     {
         for line in std::str::from_utf8(&rv.stdout).ok()?.lines() {
             match line.split_once(' ') {
-                Some((key, value)) if key == "user.email" && email.is_none() => {
+                Some((key, value)) if key == "user.email" && is_email_none => {
                     email = Some(value.to_string());
                 }
-                Some((key, value)) if key == "user.name" && name.is_none() => {
+                Some((key, value)) if key == "user.name" && is_name_none => {
                     name = Some(value.to_string());
                 }
                 _ => {}

--- a/rye/src/platform.rs
+++ b/rye/src/platform.rs
@@ -171,12 +171,13 @@ pub fn list_known_toolchains() -> Result<Vec<(PythonVersion, PathBuf)>, Error> {
 }
 
 /// Returns the default author from git or the config.
-pub fn get_default_author_with_fallback() -> Option<(String, String)> {
+pub fn get_default_author_with_fallback(dir: &PathBuf) -> Option<(String, String)> {
     let (mut name, mut email) = Config::current().default_author();
 
     if let Ok(rv) = Command::new("git")
         .arg("config")
         .arg("--get-regexp")
+        .current_dir(dir)
         .arg("^user.(name|email)$")
         .stdout(Stdio::piped())
         .output()


### PR DESCRIPTION
currently, rye cannot get correctly `user.(email|name)` from `.gitconfig` which using `includeIf` in the file. This PR is to fix this problem. closes #435 