### PR TITLE
Fix the wrong behavior when bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ _Unreleased_
 - The installer now detects `fish` and will spit out additional instructions
   for configuring the shell.
 
+- Fix the wrong behavior when bump version.
+
 <!-- released start -->
 
 ## 0.13.0

--- a/rye/src/cli/version.rs
+++ b/rye/src/cli/version.rs
@@ -65,6 +65,9 @@ fn bump_version(version: &mut Version, bump: Bump, pyproject: &mut PyProject) ->
             version.release.resize(index + 1, 0);
         }
         version.release[index] += 1;
+        for i in index + 1..version.release.len() {
+            version.release[i] = 0;
+        }
     }
 
     pyproject.set_version(version);


### PR DESCRIPTION
Fix https://github.com/mitsuhiko/rye/issues/399#issuecomment-1736693239

```
➜  rye-test git:(main) ✗ rye version
2.1.0
➜  rye-test git:(main) ✗ rye version -b patch
version bumped to 2.1.1
➜  rye-test git:(main) ✗ rye version -b minor
version bumped to 2.2.0
➜  rye-test git:(main) ✗ rye version -b major
version bumped to 3.0.0
```