### PR TITLE
Fix directory name in rust.md

### DIFF
--- a/docs/guide/rust.md
+++ b/docs/guide/rust.md
@@ -8,7 +8,7 @@ with `rye init`.
 
 ```
 rye init my-project --build-system maturin
-cd maturin
+cd my-project
 ```
 
 The following structure will be created:


### PR DESCRIPTION
Fix change directory when creating a new project using `maturin` build system