### PR TITLE
Detect windows python shim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 This file contains tracks the changes landing in Rye.  It includes changes
 that were not yet released.
 
+## 0.16.0
+
+_Unreleased_
+
+- Rye now detects the dummy Python shim that starts the windows store and
+  refuses to consider it.  #486
+
 <!-- released start -->
 
 ## 0.15.2

--- a/rye/src/cli/shim.rs
+++ b/rye/src/cli/shim.rs
@@ -219,7 +219,7 @@ fn get_shim_target(
 
         // secret pip shims
         if matches_shim(target, "pip") || matches_shim(target, "pip3") {
-            return Ok(Some(get_pip_shim(&pyproject, args, CommandOutput::Normal)?));
+            return Ok(Some(get_pip_shim(pyproject, args, CommandOutput::Normal)?));
         }
 
     // Global shims (either implicit or requested)


### PR DESCRIPTION
This improves the shim discovery code in two ways:

1. it now prints out a different error when it can't find a python shim vs any other shim
2. it now detects the dummy windows store shim implemented via applink reparse points. This is a very hacky detection and most likely will break at one point but there are no better APIs available.

Fixes #480