### PR TITLE
Add default script in pyproject.toml for init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ that were not yet released.
 
 _Unreleased_
 
+- By default a script with the name of the project is now also configured.  #519
+
 - Rye now configures hatchling better in `rye init` so that it works with
   hatchling 1.19 and later.  #521
 

--- a/rye/src/cli/init.rs
+++ b/rye/src/cli/init.rs
@@ -109,7 +109,7 @@ classifiers = ["Private :: Do Not Upload"]
 {%- endif %}
 
 [project.scripts]
-hello = {{ name~":hello"}}
+hello = {{ name ~ ":hello"}}
 
 [build-system]
 {%- if build_system == "hatchling" %}

--- a/rye/src/cli/init.rs
+++ b/rye/src/cli/init.rs
@@ -108,6 +108,9 @@ license = { text = {{ license }} }
 classifiers = ["Private :: Do Not Upload"]
 {%- endif %}
 
+[project.scripts]
+hello = {{ name~":hello"}}
+
 [build-system]
 {%- if build_system == "hatchling" %}
 requires = ["hatchling"]


### PR DESCRIPTION
Addresses https://github.com/mitsuhiko/rye/issues/319.

Currently, having scripts works as long as you do `rye sync`.  However, `rye init` does not provide a default script in `pyproject.toml` despite creating a default `__init__.py`.  This PR streamlines the developer init workflow to approximate Rust more closely so that the following works: 

1) `rye init my_project`
2) `rye sync` (after `cd my_project`)
3) `rye run hello` (no manual editing of pyproject.toml needed)

The following is now generated based on the project name: 

<img width="259" alt="image" src="https://github.com/mitsuhiko/rye/assets/34415120/84f0fe05-db6b-4f64-8db2-1fd5bd030d45">



Tested locally on a Windows 11 machine.

