### PR TITLE
fix: default script with name_safe

### DIFF
--- a/rye/src/cli/init.rs
+++ b/rye/src/cli/init.rs
@@ -109,7 +109,7 @@ classifiers = ["Private :: Do Not Upload"]
 {%- endif %}
 
 [project.scripts]
-hello = {{ name ~ ":hello"}}
+hello = {{ name_safe ~ ":hello"}}
 
 [build-system]
 {%- if build_system == "hatchling" %}


### PR DESCRIPTION
fix #526

now it succeed to init and sync

```
$ rye init foo-bar
$ cd foo-bar
$ rye sync
...
Installing collected packages: foo-bar
Successfully installed foo-bar-0.1.0
Done!
```