### PR TITLE
Use `home` cargo crate instead of `simple-home-dir`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -906,6 +906,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "i18n-config"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1788,6 +1797,7 @@ dependencies = [
  "git-testament",
  "globset",
  "hex",
+ "home",
  "indicatif",
  "junction",
  "license",
@@ -1807,7 +1817,6 @@ dependencies = [
  "serde_json",
  "sha2",
  "shlex",
- "simple-home-dir",
  "slug",
  "sysinfo",
  "tar",
@@ -1961,15 +1970,6 @@ name = "shlex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
-
-[[package]]
-name = "simple-home-dir"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8cad354eef35a6c6020953afda6d4391d9fd41d6234d7bcd2f1d7c9f6f8105d"
-dependencies = [
- "windows-sys 0.48.0",
-]
 
 [[package]]
 name = "slug"
@@ -2466,6 +2466,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.0",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2496,6 +2505,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
+]
+
+[[package]]
 name = "windows_aarch64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2506,6 +2530,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2520,6 +2550,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2530,6 +2566,12 @@ name = "windows_i686_gnu"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2544,6 +2586,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2554,6 +2602,12 @@ name = "windows_x86_64_gnu"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2568,6 +2622,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2578,6 +2638,12 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"

--- a/rye/Cargo.toml
+++ b/rye/Cargo.toml
@@ -39,7 +39,6 @@ same-file = "1.0.6"
 serde = { version = "1.0.160", features = ["derive"] }
 serde_json = "1.0.94"
 shlex = "1.1.0"
-simple-home-dir = "0.1.2"
 slug = "0.1.4"
 tar = "0.4.38"
 tempfile = "3.5.0"
@@ -59,6 +58,7 @@ configparser = "3.0.2"
 monotrail-utils = { git = "https://github.com/konstin/poc-monotrail", version = "0.0.1" }
 python-pkginfo = { version = "0.5.6", features = ["serde"] }
 sysinfo = { version = "0.29.4", default-features = false, features = [] }
+home = "0.5.9"
 
 [target."cfg(unix)".dependencies]
 whattheshell = "1.0.1"

--- a/rye/src/platform.rs
+++ b/rye/src/platform.rs
@@ -15,22 +15,9 @@ pub fn init() -> Result<(), Error> {
     let home = if let Some(rye_home) = env::var_os("RYE_HOME") {
         PathBuf::from(rye_home)
     } else {
-        {
-            // ironically the deprecated home dir implementation is
-            // still the only one that falls back to getpwuid.
-            // Fixes https://github.com/mitsuhiko/rye/issues/532
-            #[cfg(unix)]
-            {
-                #[allow(deprecated)]
-                std::env::home_dir()
-            }
-            #[cfg(not(unix))]
-            {
-                simple_home_dir::home_dir()
-            }
-        }
-        .map(|x| x.join(".rye"))
-        .ok_or_else(|| anyhow!("could not determine home folder"))?
+        home::home_dir()
+            .map(|x| x.join(".rye"))
+            .ok_or_else(|| anyhow!("could not determine home folder"))?
     };
     *APP_DIR.lock().unwrap() = Some(Box::leak(Box::new(home)));
     Ok(())


### PR DESCRIPTION
This PR replace the deprecated `std::env::home_dir()` function by `home::home_dir()` coming from cargo crates which unify the call between platforms. Feel free to close it if it's not relevant or merge it :)

Again thanks for your amazing work !