### PR TITLE
Disable revocation checks in downloader on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ _Unreleased_
 
 - Incorporate new Python builds.  #535
 
+- Disable revocation checks on windows to support corporate MITM proxies.  #537
+
 <!-- released start -->
 
 ## 0.17.0

--- a/rye/src/bootstrap.rs
+++ b/rye/src/bootstrap.rs
@@ -8,7 +8,6 @@ use std::{env, fs};
 
 use anyhow::{bail, Context, Error};
 use console::style;
-use curl::easy::SslOpt;
 use indicatif::{ProgressBar, ProgressStyle};
 use once_cell::sync::Lazy;
 use tempfile::NamedTempFile;
@@ -416,7 +415,7 @@ pub fn download_url_ignore_404(url: &str, output: CommandOutput) -> Result<Optio
     // for more information see https://github.com/curl/curl/issues/264
     #[cfg(windows)]
     {
-        handle.ssl_options(SslOpt::new().no_revoke(true))?;
+        handle.ssl_options(curl::easy::SslOpt::new().no_revoke(true))?;
     }
 
     let write_archive = &mut archive_buffer;


### PR DESCRIPTION
This disables revocation checks on windows for the downloader. Plenty other software already doesn't check that anyways, so it seems reasonable to have that as a default to fix download issues with corporate MITM proxies.

Fixes #536