### PR TITLE
Fix an issue where some packages would attempt to install weird binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ _Unreleased_
 - When using global python shims, the `.python-version` file is now correctly
   picked up in all cases.  #541
 
+- The installer will no longer attempt to symlink targets which are not valid
+  executables on the platform.  This works around some issues with Packages that
+  would prevent to install such as `changedetection.io`.  #542
+
 <!-- released start -->
 
 ## 0.17.0


### PR DESCRIPTION
In some cases the tools installer would attempt to symlink things which are not really scripts. This is caused because some python packages have stuff in the bin/scripts folder which is not actually a valid script.

It's possible to work around this oddity at installation time which is what this is now doing.

Fixes #497