### PR TITLE
Add simplified rye fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ that were not yet released.
 
 _Unreleased_
 
+- Improved the behavior of `rye fetch`.  When invoked without arguments it will now try to
+  fetch the version of the requested Python interpreter.  Specifically this combining
+  `pin` and `fetch` work in a much simplified manner.  #545
+
+- Fixed an issue where `rye init` would pin a much too specific version in the `.python-version`
+  file that is generated.  #545
+
 <!-- released start -->
 
 ## 0.18.0

--- a/docs/guide/toolchains/index.md
+++ b/docs/guide/toolchains/index.md
@@ -82,6 +82,14 @@ with `rye toolchain fetch` (also aliased to `rye fetch`):
 rye toolchain fetch cpython@3.8.5
 ```
 
+Starting with Rye 0.19.0 the argument to `fetch` is inferred from the current pin.  This means
+you can also fetch as follows:
+
+```
+rye pin 3.10
+rye fetch
+```
+
 Toolchains are fetched from two sources:
 
 * [Indygreg's Portable Python Builds](https://github.com/indygreg/python-build-standalone) for CPython

--- a/rye/src/cli/fetch.rs
+++ b/rye/src/cli/fetch.rs
@@ -1,14 +1,19 @@
-use anyhow::{Context, Error};
+use anyhow::{anyhow, Context, Error};
 use clap::Parser;
 
 use crate::bootstrap::fetch;
+use crate::platform::get_python_version_request_from_pyenv_pin;
+use crate::pyproject::PyProject;
+use crate::sources::PythonVersionRequest;
 use crate::utils::CommandOutput;
 
 /// Fetches a Python interpreter for the local machine.
 #[derive(Parser, Debug)]
 pub struct Args {
     /// The version of Python to fetch.
-    version: String,
+    ///
+    /// If no version is provided, the requested version will be fetched.
+    version: Option<String>,
     /// Overrides the architecture to fetch.
     ///
     /// When a non native architecture is fetched, the toolchain is
@@ -24,6 +29,20 @@ pub struct Args {
 
 pub fn execute(cmd: Args) -> Result<(), Error> {
     let output = CommandOutput::from_quiet_and_verbose(cmd.quiet, cmd.verbose);
-    fetch(&cmd.version.parse()?, output).context("error while fetching python installation")?;
+
+    let version: PythonVersionRequest = match cmd.version {
+        Some(version) => version.parse()?,
+        None => {
+            if let Ok(pyproject) = PyProject::discover() {
+                pyproject.venv_python_version()?.into()
+            } else {
+                get_python_version_request_from_pyenv_pin(&std::env::current_dir()?).ok_or_else(
+                    || anyhow!("not sure what to fetch, please provide an explicit version"),
+                )?
+            }
+        }
+    };
+
+    fetch(&version, output).context("error while fetching python installation")?;
     Ok(())
 }


### PR DESCRIPTION
This improves the behavior of `rye fetch`. When invoked without arguments it will now try to fetch the version of the requested Python interpreter. Specifically this makes the following command work even without an installed Python interpreter without manually having to copy paste anything:

```
rye pin 3.8
rye fetch
python
```

The help message is now also adjusted.  Additionally this fixes an issue where the `.python-version` created by the `rye init` command would freeze a to specific version request (usually with architecture). Behavior is now aligned with `rye pin`.