### PR TITLE
Add ruff powered lint and fmt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ _Unreleased_
 - Update to newer versions of pip tools.  For Python 3.7 `6.14.0` is used, for
   new Python versions `7.3.0` is used.  #554
 
+- Added `rye fmt` and `rye lint` commands to format and lint with
+  the help of Ruff.  #555
+
 <!-- released start -->
 
 ## 0.19.0

--- a/rye/src/bootstrap.rs
+++ b/rye/src/bootstrap.rs
@@ -36,7 +36,7 @@ pub const SELF_PYTHON_TARGET_VERSION: PythonVersionRequest = PythonVersionReques
     suffix: None,
 };
 
-const SELF_VERSION: u64 = 7;
+const SELF_VERSION: u64 = 8;
 
 const SELF_REQUIREMENTS: &str = r#"
 build==1.0.3
@@ -55,6 +55,7 @@ twine==4.0.2
 unearth==0.12.1
 urllib3==2.0.7
 virtualenv==20.25.0
+ruff==0.1.14
 "#;
 
 static FORCED_TO_UPDATE: AtomicBool = AtomicBool::new(false);

--- a/rye/src/cli/fmt.rs
+++ b/rye/src/cli/fmt.rs
@@ -1,0 +1,77 @@
+use std::ffi::OsString;
+use std::path::PathBuf;
+use std::process::Command;
+
+use anyhow::Error;
+use clap::Parser;
+
+use crate::bootstrap::ensure_self_venv;
+use crate::consts::VENV_BIN;
+use crate::pyproject::{locate_projects, PyProject};
+use crate::utils::{CommandOutput, QuietExit};
+
+/// Run the code formatter on the project.
+///
+/// This invokes ruff in format mode.
+#[derive(Parser, Debug)]
+pub struct Args {
+    /// Format all packages
+    #[arg(short, long)]
+    all: bool,
+    /// Format a specific package
+    #[arg(short, long)]
+    package: Vec<String>,
+    /// Use this pyproject.toml file
+    #[arg(long, value_name = "PYPROJECT_TOML")]
+    pyproject: Option<PathBuf>,
+    /// Run format in check mode
+    #[arg(long)]
+    check: bool,
+    /// Enables verbose diagnostics.
+    #[arg(short, long)]
+    verbose: bool,
+    /// Turns off all output.
+    #[arg(short, long, conflicts_with = "verbose")]
+    quiet: bool,
+    /// Extra arguments to the formatter
+    #[arg(trailing_var_arg = true)]
+    extra_args: Vec<OsString>,
+}
+
+pub fn execute(cmd: Args) -> Result<(), Error> {
+    let project = PyProject::load_or_discover(cmd.pyproject.as_deref())?;
+    let output = CommandOutput::from_quiet_and_verbose(cmd.quiet, cmd.verbose);
+    let venv = ensure_self_venv(output)?;
+    let ruff = venv.join(VENV_BIN).join("ruff");
+
+    let mut ruff_cmd = Command::new(ruff);
+    ruff_cmd.arg("format");
+    match output {
+        CommandOutput::Normal => {}
+        CommandOutput::Verbose => {
+            ruff_cmd.arg("--verbose");
+        }
+        CommandOutput::Quiet => {
+            ruff_cmd.arg("-q");
+        }
+    }
+
+    if cmd.check {
+        ruff_cmd.arg("--check");
+    }
+    ruff_cmd.args(cmd.extra_args);
+
+    ruff_cmd.arg("--");
+    let projects = locate_projects(project, cmd.all, &cmd.package[..])?;
+    for project in projects {
+        ruff_cmd.arg(project.root_path().as_os_str());
+    }
+
+    let status = ruff_cmd.status()?;
+    if !status.success() {
+        let code = status.code().unwrap_or(1);
+        Err(QuietExit(code).into())
+    } else {
+        Ok(())
+    }
+}

--- a/rye/src/cli/lint.rs
+++ b/rye/src/cli/lint.rs
@@ -1,0 +1,77 @@
+use std::ffi::OsString;
+use std::path::PathBuf;
+use std::process::Command;
+
+use anyhow::Error;
+use clap::Parser;
+
+use crate::bootstrap::ensure_self_venv;
+use crate::consts::VENV_BIN;
+use crate::pyproject::{locate_projects, PyProject};
+use crate::utils::{CommandOutput, QuietExit};
+
+/// Run the linter on the project.
+///
+/// This invokes ruff in lint mode.
+#[derive(Parser, Debug)]
+pub struct Args {
+    /// Linter all packages
+    #[arg(short, long)]
+    all: bool,
+    /// Lint a specific package
+    #[arg(short, long)]
+    package: Vec<String>,
+    /// Use this pyproject.toml file
+    #[arg(long, value_name = "PYPROJECT_TOML")]
+    pyproject: Option<PathBuf>,
+    /// Apply fixes.
+    #[arg(long)]
+    fix: bool,
+    /// Enables verbose diagnostics.
+    #[arg(short, long)]
+    verbose: bool,
+    /// Turns off all output.
+    #[arg(short, long, conflicts_with = "verbose")]
+    quiet: bool,
+    /// Extra arguments to the linter
+    #[arg(trailing_var_arg = true)]
+    extra_args: Vec<OsString>,
+}
+
+pub fn execute(cmd: Args) -> Result<(), Error> {
+    let project = PyProject::load_or_discover(cmd.pyproject.as_deref())?;
+    let output = CommandOutput::from_quiet_and_verbose(cmd.quiet, cmd.verbose);
+    let venv = ensure_self_venv(output)?;
+    let ruff = venv.join(VENV_BIN).join("ruff");
+
+    let mut ruff_cmd = Command::new(ruff);
+    ruff_cmd.arg("check");
+    match output {
+        CommandOutput::Normal => {}
+        CommandOutput::Verbose => {
+            ruff_cmd.arg("--verbose");
+        }
+        CommandOutput::Quiet => {
+            ruff_cmd.arg("-q");
+        }
+    }
+
+    if cmd.fix {
+        ruff_cmd.arg("--fix");
+    }
+    ruff_cmd.args(cmd.extra_args);
+
+    ruff_cmd.arg("--");
+    let projects = locate_projects(project, cmd.all, &cmd.package[..])?;
+    for project in projects {
+        ruff_cmd.arg(project.root_path().as_os_str());
+    }
+
+    let status = ruff_cmd.status()?;
+    if !status.success() {
+        let code = status.code().unwrap_or(1);
+        Err(QuietExit(code).into())
+    } else {
+        Ok(())
+    }
+}

--- a/rye/src/cli/mod.rs
+++ b/rye/src/cli/mod.rs
@@ -7,8 +7,10 @@ mod add;
 mod build;
 mod config;
 mod fetch;
+mod fmt;
 mod init;
 mod install;
+mod lint;
 mod lock;
 mod make_req;
 mod pin;
@@ -49,9 +51,12 @@ enum Command {
     Build(build::Args),
     Config(config::Args),
     Fetch(fetch::Args),
+    #[command(alias = "format")]
+    Fmt(fmt::Args),
     Init(init::Args),
     Install(install::Args),
     Lock(lock::Args),
+    Lint(lint::Args),
     MakeReq(make_req::Args),
     Pin(pin::Args),
     Publish(publish::Args),
@@ -107,9 +112,11 @@ pub fn execute() -> Result<(), Error> {
         Command::Build(cmd) => build::execute(cmd),
         Command::Config(cmd) => config::execute(cmd),
         Command::Fetch(cmd) => fetch::execute(cmd),
+        Command::Fmt(cmd) => fmt::execute(cmd),
         Command::Init(cmd) => init::execute(cmd),
         Command::Install(cmd) => install::execute(cmd),
         Command::Lock(cmd) => lock::execute(cmd),
+        Command::Lint(cmd) => lint::execute(cmd),
         Command::MakeReq(cmd) => make_req::execute(cmd),
         Command::Pin(cmd) => pin::execute(cmd),
         Command::Publish(cmd) => publish::execute(cmd),

--- a/rye/src/cli/mod.rs
+++ b/rye/src/cli/mod.rs
@@ -56,6 +56,7 @@ enum Command {
     Init(init::Args),
     Install(install::Args),
     Lock(lock::Args),
+    #[command(alias = "check")]
     Lint(lint::Args),
     MakeReq(make_req::Args),
     Pin(pin::Args),


### PR DESCRIPTION
This adds two new commands `fmt` (aliased to `format`) and `lint` (aliased to `check`) which invoke ruff. This is similar to how `cargo fmt` and `cargo clippy` invoke `rustfmt` and `clippy` behind the scenes.

I do want to make this configurable in the future, but this is a good starting point.