### PR TITLE
Explicitly handle ctrl-c to restore cursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ _Unreleased_
 - Added `rye fmt` and `rye lint` commands to format and lint with
   the help of Ruff.  #555
 
+- Restore cursor state on Ctrl-C.  This fixes some issues where in rare cases the
+  cursor would disappear even after shutting down rye.  #564
+
 <!-- released start -->
 
 ## 0.19.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,6 +438,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b467862cc8610ca6fc9a1532d7777cee0804e678ab45410897b9396495994a0b"
+dependencies = [
+ "nix",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "curl"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1785,6 +1795,7 @@ dependencies = [
  "clap_complete",
  "configparser",
  "console",
+ "ctrlc",
  "curl",
  "decompress",
  "dialoguer",

--- a/rye/Cargo.toml
+++ b/rye/Cargo.toml
@@ -59,6 +59,7 @@ monotrail-utils = { git = "https://github.com/konstin/poc-monotrail", version = 
 python-pkginfo = { version = "0.6.0", features = ["serde"] }
 sysinfo = { version = "0.29.4", default-features = false, features = [] }
 home = "0.5.9"
+ctrlc = "3.4.2"
 
 [target."cfg(unix)".dependencies]
 whattheshell = "1.0.1"


### PR DESCRIPTION
Restore cursor visibility on ctrl+c.