### PR TITLE
Add functionality to specify target files in fmt and lint commands

### DIFF
--- a/rye/src/cli/fmt.rs
+++ b/rye/src/cli/fmt.rs
@@ -15,6 +15,9 @@ use crate::utils::{CommandOutput, QuietExit};
 /// This invokes ruff in format mode.
 #[derive(Parser, Debug)]
 pub struct Args {
+    /// List of files or directories to format
+    #[clap()]
+    pub files: Vec<PathBuf>,
     /// Format all packages
     #[arg(short, long)]
     all: bool,
@@ -34,7 +37,7 @@ pub struct Args {
     #[arg(short, long, conflicts_with = "verbose")]
     quiet: bool,
     /// Extra arguments to the formatter
-    #[arg(trailing_var_arg = true)]
+    #[arg(last = true)]
     extra_args: Vec<OsString>,
 }
 
@@ -62,9 +65,15 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
     ruff_cmd.args(cmd.extra_args);
 
     ruff_cmd.arg("--");
-    let projects = locate_projects(project, cmd.all, &cmd.package[..])?;
-    for project in projects {
-        ruff_cmd.arg(project.root_path().as_os_str());
+    if cmd.files.is_empty() {
+        let projects = locate_projects(project, cmd.all, &cmd.package[..])?;
+        for project in projects {
+            ruff_cmd.arg(project.root_path().as_os_str());
+        }
+    } else {
+        for file in cmd.files {
+            ruff_cmd.arg(file.as_os_str());
+        }
     }
 
     let status = ruff_cmd.status()?;

--- a/rye/src/cli/lint.rs
+++ b/rye/src/cli/lint.rs
@@ -15,6 +15,9 @@ use crate::utils::{CommandOutput, QuietExit};
 /// This invokes ruff in lint mode.
 #[derive(Parser, Debug)]
 pub struct Args {
+    /// List of files or directories to lint
+    #[clap()]
+    pub files: Vec<PathBuf>,
     /// Lint all packages
     #[arg(short, long)]
     all: bool,
@@ -34,7 +37,7 @@ pub struct Args {
     #[arg(short, long, conflicts_with = "verbose")]
     quiet: bool,
     /// Extra arguments to the linter
-    #[arg(trailing_var_arg = true)]
+    #[arg(last = true)]
     extra_args: Vec<OsString>,
 }
 
@@ -62,9 +65,15 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
     ruff_cmd.args(cmd.extra_args);
 
     ruff_cmd.arg("--");
-    let projects = locate_projects(project, cmd.all, &cmd.package[..])?;
-    for project in projects {
-        ruff_cmd.arg(project.root_path().as_os_str());
+    if cmd.files.is_empty() {
+        let projects = locate_projects(project, cmd.all, &cmd.package[..])?;
+        for project in projects {
+            ruff_cmd.arg(project.root_path().as_os_str());
+        }
+    } else {
+        for file in cmd.files {
+            ruff_cmd.arg(file.as_os_str());
+        }
     }
 
     let status = ruff_cmd.status()?;


### PR DESCRIPTION
Allow the `rye fmt` and `rye lint` commands to explicitly specify files/directories to format.

When using `rye fmt` or similar commands primarily as an auto-formatter within an editor, latency can be further reduced by formatting only open files.
This PR allows `rye fmt` and `rye lint` to take a list of files to format as variable length arguments, and if the list is not empty, to format only those files, not the project (as with Ruff). Extra arguments can be written after the `--`.