### PR TITLE
Prompt for default toolchain on installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ _Unreleased_
   global shims were not properly defaulted which required the user to be explicit
   with the fetch request.  #574
 
+- The rye installer now prompts for the default toolchain version if global shims
+  are enabled.  #576
+
+- The internal Python version was bumped to 3.12.  #576
+
 <!-- released start -->
 
 ## 0.20.0

--- a/rye/src/bootstrap.rs
+++ b/rye/src/bootstrap.rs
@@ -31,12 +31,12 @@ pub const SELF_PYTHON_TARGET_VERSION: PythonVersionRequest = PythonVersionReques
     arch: None,
     os: None,
     major: 3,
-    minor: Some(11),
+    minor: Some(12),
     patch: None,
     suffix: None,
 };
 
-const SELF_VERSION: u64 = 8;
+const SELF_VERSION: u64 = 9;
 
 const SELF_REQUIREMENTS: &str = r#"
 build==1.0.3

--- a/rye/src/utils/mod.rs
+++ b/rye/src/utils/mod.rs
@@ -387,6 +387,21 @@ pub fn reformat_toml_array_multiline(deps: &mut Array) {
     deps.set_trailing_comma(true);
 }
 
+/// Given a toml document, ensures that a given named table exists toplevel.
+///
+/// The table is created as a non inline table which is the preferred style.
+pub fn ensure_toml_table<'a>(
+    doc: &'a mut toml_edit::Document,
+    name: &str,
+) -> &'a mut toml_edit::Item {
+    if doc.as_item().get(name).is_none() {
+        let mut tbl = toml_edit::Table::new();
+        tbl.set_implicit(true);
+        doc.as_item_mut()[name] = toml_edit::Item::Table(tbl);
+    }
+    &mut doc.as_item_mut()[name]
+}
+
 pub fn escape_string(s: String) -> String {
     s.trim().replace(['\\', '"'], "")
 }


### PR DESCRIPTION
Rye now prompts for the default toolchain and persists it in the config when global shims are enabled.

Fixes #573 