### PR TITLE
Automatically add to PATH on UNIX shells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ _Unreleased_
 
 - The internal Python version was bumped to 3.12.  #576
 
+- The installer now can automatically add Rye to `PATH` on most UNIX environments.  #580
+
 <!-- released start -->
 
 ## 0.20.0

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -51,14 +51,22 @@ This folder is a folder that contains "shims" which are executables that
 Rye manages for you as well as the `rye` executable itself.  For instance any
 Python installation managed by Rye will be available via a shim placed there.
 
-On macOS or Linux you can accomplish this by adding it to your `.bashrc`, `.zshrc`
+On macOS or Linux you can accomplish this by adding it to your `.profile` file
 or similar.  This step is technically optional but required if you want to be able to
 just type `python` or `rye` into the shell to pick up the current virtualenv's Python
-interpreter.
+interpreter.  The installer will offer to do this for you automatically.  If you
+opt-out, or you run a custom shell you will need to do this manually.
 
 === "Bash"
 
     Rye ships an `env` file which should be sourced to update `PATH` automatically.
+
+    ```bash
+    echo 'source "$HOME/.rye/env"' >> ~/.profile
+    ```
+
+    In some setups `.profile` is not sourced, in which case you can add it to your
+    `.bashrc` instead:
 
     ```bash
     echo 'source "$HOME/.rye/env"' >> ~/.bashrc
@@ -69,7 +77,14 @@ interpreter.
     Rye ships an `env` file which should be sourced to update `PATH` automatically.
 
     ```bash
-    echo 'source "$HOME/.rye/env"' >> ~/.zshrc
+    echo 'source "$HOME/.rye/env"' >> ~/.profile
+    ```
+
+    In some setups `.profile` is not sourced, in which case you can add it to your
+    `.zprofile` instead:
+
+    ```bash
+    echo 'source "$HOME/.rye/env"' >> ~/.zprofile
     ```
 
 === "Fish"
@@ -80,6 +95,16 @@ interpreter.
 
     ```bash
     set -Ua fish_user_paths "$HOME/.rye/shims"
+    ```
+
+=== "Nushell"
+
+    Since nushell does not support `env` files, you instead need to add
+    the shims directly.  This can be accomplished by adding this to your
+    `env.nu` file:
+
+    ```shell
+    $env.PATH = ($env.PATH | split row (char esep) | append "~/.rye/shims")
     ```
 
 === "Unix Shells"

--- a/rye/src/bootstrap.rs
+++ b/rye/src/bootstrap.rs
@@ -308,9 +308,9 @@ pub fn get_pip_module(venv: &Path) -> Result<PathBuf, Error> {
     Ok(rv)
 }
 
-/// we only support cpython 3.9 to 3.11
+/// we only support cpython 3.9 to 3.12
 pub fn is_self_compatible_toolchain(version: &PythonVersion) -> bool {
-    version.name == "cpython" && version.major == 3 && version.minor >= 9 && version.minor < 12
+    version.name == "cpython" && version.major == 3 && version.minor >= 9 && version.minor <= 12
 }
 
 fn ensure_self_toolchain(output: CommandOutput) -> Result<PythonVersion, Error> {

--- a/rye/src/utils/mod.rs
+++ b/rye/src/utils/mod.rs
@@ -32,6 +32,9 @@ pub fn tui_theme() -> &'static dyn Theme {
 #[cfg(windows)]
 pub(crate) mod windows;
 
+#[cfg(unix)]
+pub(crate) mod unix;
+
 #[cfg(windows)]
 pub fn symlink_dir<P, Q>(original: P, link: Q) -> Result<(), std::io::Error>
 where

--- a/rye/src/utils/unix.rs
+++ b/rye/src/utils/unix.rs
@@ -1,0 +1,43 @@
+use std::path::{Path, PathBuf};
+use std::{env, fs};
+
+use anyhow::{Context, Error};
+
+pub(crate) fn add_to_path(rye_home: &Path) -> Result<(), Error> {
+    // for regular shells just add the path to `.profile`
+    add_source_line_to_profile(
+        &home::home_dir()
+            .context("could not find home dir")?
+            .join(".profile"),
+        &(format!(
+            ". \"{}\"",
+            reverse_resolve_env_home(rye_home.join("env")).display()
+        )),
+    )?;
+    Ok(())
+}
+
+fn add_source_line_to_profile(profile_path: &Path, source_line: &str) -> Result<(), Error> {
+    let mut profile = if profile_path.is_file() {
+        fs::read_to_string(profile_path)?
+    } else {
+        String::new()
+    };
+
+    if !profile.lines().any(|x| x.trim() == source_line) {
+        profile.push_str(source_line);
+        profile.push('\n');
+        fs::write(profile_path, profile).context("failed to write updated .profile")?;
+    }
+
+    Ok(())
+}
+
+fn reverse_resolve_env_home(path: PathBuf) -> PathBuf {
+    if let Some(env_home) = env::var_os("HOME").map(PathBuf::from) {
+        if let Ok(rest) = path.strip_prefix(&env_home) {
+            return Path::new("$HOME").join(rest);
+        }
+    }
+    path
+}


### PR DESCRIPTION
This automatically adds rye to `PATH` on unix shells.

This commit also fixes a bad internal compatibility reference that can cause confusing during installation.