### PR TITLE
Added support for marking virtualenvs ignored for cloud sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ that were not yet released.
 
 _Unreleased_
 
+- Virtual envs managed by Rye will now by default be marked to not sync to
+  known cloud storage systems (Dropbox and iCloud).  #589
+
 <!-- released start -->
 
 ## 0.21.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1840,6 +1840,7 @@ dependencies = [
  "which",
  "winapi",
  "winreg",
+ "xattr",
  "zip",
  "zstd 0.13.0",
 ]

--- a/docs/guide/config.md
+++ b/docs/guide/config.md
@@ -81,6 +81,12 @@ force-rye-managed = false
 # virtual environments.
 global-python = false
 
+# Marks the managed .venv in a way that cloud based synchronization systems
+# like Dropbox and iCloud Files will not upload it.  This defaults to true
+# as a .venv in cloud storage typically does not make sense.  Set this to
+# `false` to disable this behavior.
+venv-mark-sync-ignore = true
+
 # a array of tables with optional sources.  Same format as in pyproject.toml
 [[sources]]
 name = "default"

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -149,3 +149,19 @@ wheel is built:
 [tool.hatch.build.targets.sdist]
 include = ["src/my_package", "tests"]
 ```
+
+## Can I Relocate Virtualenvs?
+
+Rye very intentionally places the virtualenv (`.venv`) in the root folder of the
+workspace.  Relocations of virtualenvs is not supported.  This is a very intentional
+decision so that tools do not need to deal with various complex alternatives and can
+rely on a simple algorithm to locate it.  This is a form of convention over configuration
+and can also assist editor integrations.
+
+There are some known downsides of this.  For instance if you are placing your projects
+in Dropbox, it would cause this folder to synchronize.  As a way to combat this, Rye
+will automatically mark the virtualenv with the necessary flags to disable cloud sync
+of known supported cloud synchronization systems.
+
+For override this behavior you can set the `behavior.venv-mark-sync-ignore` configuration
+key to `false`.

--- a/rye/Cargo.toml
+++ b/rye/Cargo.toml
@@ -63,6 +63,7 @@ ctrlc = "3.4.2"
 
 [target."cfg(unix)".dependencies]
 whattheshell = "1.0.1"
+xattr = "1.3.1"
 
 [target."cfg(windows)".dependencies]
 winapi = { version = "0.3.9", default-features = false, features = [] }

--- a/rye/src/config.rs
+++ b/rye/src/config.rs
@@ -186,6 +186,15 @@ impl Config {
             .unwrap_or(false)
     }
 
+    /// Mark the `.venv` to not sync to cloud storage
+    pub fn venv_mark_sync_ignore(&self) -> bool {
+        self.doc
+            .get("behavior")
+            .and_then(|x| x.get("venv-mark-sync-ignore"))
+            .and_then(|x| x.as_bool())
+            .unwrap_or(true)
+    }
+
     /// Returns the HTTP proxy that should be used.
     pub fn http_proxy_url(&self) -> Option<String> {
         std::env::var("http_proxy").ok().or_else(|| {

--- a/rye/src/utils/mod.rs
+++ b/rye/src/utils/mod.rs
@@ -52,6 +52,36 @@ where
     }
 }
 
+/// Given the path to a folder this adds or removes a cloud sync flag
+/// on the folder.
+///
+/// Today this only supports dropbox and apple icloud.
+pub fn mark_path_sync_ignore(venv: &Path, mark_ignore: bool) -> Result<(), Error> {
+    #[cfg(unix)]
+    {
+        for flag in ["com.dropbox.ignored", "com.apple.fileprovider.ignore#P"] {
+            if mark_ignore {
+                xattr::set(venv, flag, b"1")?;
+            } else {
+                xattr::remove(venv, flag)?;
+            }
+        }
+    }
+
+    #[cfg(windows)]
+    {
+        let mut stream_path = venv.as_os_str().to_os_string();
+        stream_path.push(":com.dropbox.ignored");
+        if mark_ignore {
+            fs::write(stream_path, b"1")?;
+        } else {
+            fs::remove_file(stream_path).ok();
+        }
+    }
+
+    Ok(())
+}
+
 #[derive(Debug)]
 pub struct QuietExit(pub i32);
 


### PR DESCRIPTION
By default rye will now mark virtualenvs to not sync to cloud storage (iCloud and Dropbox).

**Todo:**

* [x] docs
* [ ] testing on windows

Fixes #585