### PR TITLE
On sync ensure that pip tools are bootstrap in the right order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ _Unreleased_
 - Virtual envs managed by Rye will now by default be marked to not sync to
   known cloud storage systems (Dropbox and iCloud).  #589
 
+- Fixed a bug where pip-tools sometimes did not get initialized.  #596
+
 <!-- released start -->
 
 ## 0.21.0

--- a/rye/src/piptools.rs
+++ b/rye/src/piptools.rs
@@ -34,7 +34,7 @@ impl PipToolsVersion {
 
 fn get_pip_tools_bin(py_ver: &PythonVersion, output: CommandOutput) -> Result<PathBuf, Error> {
     let self_venv = ensure_self_venv(output)?;
-    let venv = get_pip_tools_venv(py_ver);
+    let venv = get_pip_tools_venv_path(py_ver);
 
     let py = get_venv_python_bin(&venv);
     let version = get_pip_tools_version(py_ver);
@@ -77,7 +77,7 @@ pub fn get_pip_tools_version(py_ver: &PythonVersion) -> PipToolsVersion {
     }
 }
 
-pub fn get_pip_tools_venv(py_ver: &PythonVersion) -> PathBuf {
+pub fn get_pip_tools_venv_path(py_ver: &PythonVersion) -> PathBuf {
     let key = format!("{}@{}.{}", py_ver.name, py_ver.major, py_ver.minor);
     get_app_dir().join("pip-tools").join(key)
 }


### PR DESCRIPTION
It's possible on some platforms that the pip tools bootstrapping happens after the path to pip was looked up. This fixes this which should fix some cases where on first attempt pip tools did not get initialized.

Fixes #594