### PR TITLE
Select latest compatible installed toolchain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ _Unreleased_
 
 - Fixed a bug where pip-tools sometimes did not get initialized.  #596
 
+- Rye now prefers installed toolchains over newer latest toolchains unless
+  a precise pin is used.  #598
+
 <!-- released start -->
 
 ## 0.21.0

--- a/docs/guide/commands/pin.md
+++ b/docs/guide/commands/pin.md
@@ -7,6 +7,12 @@ Additionally it will update `requires-python` in the `pyproject.toml` if it's
 lower than the current version.  This can be disabled by passing
 `--no-update-requires-python`.
 
+Which toolchain Rye prefers depends on the Rye version.  From 0.22 onwards
+the latest compatible installed toolchain is picked, and only if a non
+existing one is found a download will be attempted.  For older versions
+Rye will always attempt to download the latest available if it's not
+installed yet unless a precise pin is selected.
+
 ## Example
 
 Pin a specific version of Python:

--- a/rye/src/platform.rs
+++ b/rye/src/platform.rs
@@ -124,6 +124,7 @@ pub fn get_pinnable_version(req: &PythonVersionRequest, relaxed: bool) -> Option
         }
 
         // otherwise, any version we can download is an acceptable version
+        // by try to pin to something we already have.
         if target_version.is_none() {
             if let Some(version) = latest_available_python_version(req) {
                 target_version = Some(version);

--- a/rye/src/pyproject.rs
+++ b/rye/src/pyproject.rs
@@ -1065,7 +1065,8 @@ pub fn get_current_venv_python_version(venv_path: &Path) -> Option<PythonVersion
 
 /// Give a given python version request, returns the latest available version.
 ///
-/// This can return a version that requires downloading.
+/// This can return a version that requires downloading but only if no matching
+/// Python version was found locally.
 pub fn latest_available_python_version(
     requested_version: &PythonVersionRequest,
 ) -> Option<PythonVersion> {
@@ -1084,9 +1085,13 @@ pub fn latest_available_python_version(
         Vec::new()
     };
 
-    if let Some((latest, _, _)) = get_download_url(requested_version) {
-        all.push(latest);
-    };
+    // if we don't have a match yet, try to fill it in with the latest
+    // version we are capable of fetching from the internet.
+    if all.is_empty() {
+        if let Some((latest, _, _)) = get_download_url(requested_version) {
+            all.push(latest);
+        };
+    }
 
     all.sort();
     all.into_iter().next_back()


### PR DESCRIPTION
This changes rye to only prefer the latest version if a compatible already installed toolchain wasn't found. This also fixes an issue where the internal pip-tools venv might be left behind stale when a toolchain was removed.

Fixes #586