### PR TITLE
Added support for bootstrapping with specific toolchain version

### DIFF
--- a/rye/src/bootstrap.rs
+++ b/rye/src/bootstrap.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 use std::sync::atomic::{self, AtomicBool};
 use std::{env, fs};
 
-use anyhow::{bail, Context, Error};
+use anyhow::{anyhow, bail, Context, Error};
 use console::style;
 use indicatif::{ProgressBar, ProgressStyle};
 use once_cell::sync::Lazy;
@@ -19,6 +19,7 @@ use crate::platform::{
     get_app_dir, get_canonical_py_path, get_toolchain_python_bin, list_known_toolchains,
     symlinks_supported,
 };
+use crate::pyproject::latest_available_python_version;
 use crate::sources::{get_download_url, PythonVersion, PythonVersionRequest};
 use crate::utils::{
     check_checksum, get_venv_python_bin, set_proxy_variables, symlink_file, unpack_archive,
@@ -71,6 +72,14 @@ fn is_up_to_date() -> bool {
 
 /// Bootstraps the venv for rye itself
 pub fn ensure_self_venv(output: CommandOutput) -> Result<PathBuf, Error> {
+    ensure_self_venv_with_toolchain(output, None)
+}
+
+/// Bootstraps the venv for rye itself
+pub fn ensure_self_venv_with_toolchain(
+    output: CommandOutput,
+    toolchain_version_request: Option<PythonVersionRequest>,
+) -> Result<PathBuf, Error> {
     let app_dir = get_app_dir();
     let venv_dir = app_dir.join("self");
     let pip_tools_dir = app_dir.join("pip-tools");
@@ -94,12 +103,22 @@ pub fn ensure_self_venv(output: CommandOutput) -> Result<PathBuf, Error> {
         echo!("Bootstrapping rye internals");
     }
 
-    let version = ensure_self_toolchain(output).with_context(|| {
-        format!(
-            "failed to fetch internal cpython toolchain {}",
-            SELF_PYTHON_TARGET_VERSION
-        )
-    })?;
+    let version = match toolchain_version_request {
+        Some(ref version_request) => ensure_specific_self_toolchain(output, version_request)
+            .with_context(|| {
+                format!(
+                    "failed to provision internal cpython toolchain {}",
+                    version_request
+                )
+            })?,
+        None => ensure_latest_self_toolchain(output).with_context(|| {
+            format!(
+                "failed to fetch internal cpython toolchain {}",
+                SELF_PYTHON_TARGET_VERSION
+            )
+        })?,
+    };
+
     let py_bin = get_toolchain_python_bin(&version)?;
 
     // linux specific detection of shared libraries.
@@ -313,21 +332,57 @@ pub fn is_self_compatible_toolchain(version: &PythonVersion) -> bool {
     version.name == "cpython" && version.major == 3 && version.minor >= 9 && version.minor <= 12
 }
 
-fn ensure_self_toolchain(output: CommandOutput) -> Result<PythonVersion, Error> {
-    let possible_versions = list_known_toolchains()?
+/// Ensure that the toolchain for the self environment is available.
+fn ensure_latest_self_toolchain(output: CommandOutput) -> Result<PythonVersion, Error> {
+    if let Some(version) = list_known_toolchains()?
         .into_iter()
         .map(|x| x.0)
         .filter(is_self_compatible_toolchain)
-        .collect::<Vec<_>>();
-
-    if let Some(version) = possible_versions.into_iter().max() {
-        echo!(
-            "Found a compatible python version: {}",
-            style(&version).cyan()
-        );
+        .collect::<Vec<_>>()
+        .into_iter()
+        .max()
+    {
+        if output != CommandOutput::Quiet {
+            echo!(
+                "Found a compatible python version: {}",
+                style(&version).cyan()
+            );
+        }
         Ok(version)
     } else {
         fetch(&SELF_PYTHON_TARGET_VERSION, output)
+    }
+}
+
+/// Ensure a specific toolchain is available.
+fn ensure_specific_self_toolchain(
+    output: CommandOutput,
+    toolchain_version_request: &PythonVersionRequest,
+) -> Result<PythonVersion, Error> {
+    let toolchain_version = latest_available_python_version(toolchain_version_request)
+        .ok_or_else(|| anyhow!("requested toolchain version is not available"))?;
+    if !is_self_compatible_toolchain(&toolchain_version) {
+        bail!(
+            "the requested toolchain version ({}) is not supported for rye-internal usage",
+            toolchain_version
+        );
+    }
+    if !get_toolchain_python_bin(&toolchain_version)?.is_file() {
+        if output != CommandOutput::Quiet {
+            echo!(
+                "Fetching requested internal toolchain '{}'",
+                toolchain_version
+            );
+        }
+        fetch(&toolchain_version.into(), output)
+    } else {
+        if output != CommandOutput::Quiet {
+            echo!(
+                "Found a compatible python version: {}",
+                style(&toolchain_version).cyan()
+            );
+        }
+        Ok(toolchain_version)
     }
 }
 /// Fetches a version if missing.

--- a/rye/src/cli/shim.rs
+++ b/rye/src/cli/shim.rs
@@ -13,7 +13,7 @@ use crate::config::Config;
 use crate::consts::VENV_BIN;
 use crate::platform::{get_python_version_request_from_pyenv_pin, get_toolchain_python_bin};
 use crate::pyproject::{latest_available_python_version, PyProject};
-use crate::sources::{PythonVersion, PythonVersionRequest};
+use crate::sources::PythonVersionRequest;
 use crate::sync::{sync, SyncOptions};
 use crate::tui::redirect_to_stderr;
 use crate::utils::{exec_spawn, get_venv_python_bin, CommandOutput};
@@ -253,11 +253,8 @@ fn get_shim_target(
             return find_shadowed_target(target, args);
         };
 
-        let py_ver = match PythonVersion::try_from(version_request.clone()) {
-            Ok(py_ver) => py_ver,
-            Err(_) => latest_available_python_version(&version_request)
-                .ok_or_else(|| anyhow!("Unable to determine target Python version"))?,
-        };
+        let py_ver = latest_available_python_version(&version_request)
+            .ok_or_else(|| anyhow!("Unable to determine target Python version"))?;
         let py = get_toolchain_python_bin(&py_ver)?;
         if !py.is_file() {
             let hint = if implicit_request {


### PR DESCRIPTION
This is a pretty messy change that changes how bootstrapping can work. This in reference to #605 

The motivation here is that a user can bootstrap rye and point it to a specific Python version. Today this already works with `RYE_TOOLCHAIN` to a toolchain that is available on the file system. However this now also adds `RYE_TOOLCHAIN_VERSION` which registers a specific toolchain rather than the current latest version. This only allows a toolchain to be registered that is compatible with the version range supported by the system.

```shell
curl -sSf https://rye-up.com/get | RYE_TOOLCHAIN_VERSION="3.9" RYE_INSTALL_OPTION="--yes" bash
```