### PR TITLE
I have fixed typo error from the update.md file

### DIFF
--- a/docs/guide/commands/self/update.md
+++ b/docs/guide/commands/self/update.md
@@ -10,7 +10,7 @@ compilation of Rye if Rust is installed.
 Update to the latest version:
 
 ```
-$ rye self udpate
+$ rye self update
 ```
 
 Update (or downgrade)  to a specific version:


### PR DESCRIPTION
## Issue Description

In the README.md file of the project, there is a typo in the command example provided for updating Rye. The typo occurs in the "Example" section under the "update" command heading. The incorrect command is written as `$ rye self udpate`, where "udpate" should actually be "update".

### Steps to Reproduce

1. Navigate to the README.md file of the project.
2. Locate the "Example" section under the "update" command heading.
3. Observe the command provided: `$ rye self udpate`.

### Expected Behavior

The command example provided in the README.md file should accurately reflect the syntax for updating Rye, with the correct spelling of "update".

### Actual Behavior

The README.md file contains a typo in the command example for updating Rye, with the word "udpate" instead of "update".

### Proposed Solution

- Update the typo in the README.md file by replacing "udpate" with "update".
- Ensure consistency and correctness in the provided command examples for users' reference.

This fix will enhance the clarity and usability of the documentation for users seeking to update Rye.
