### PR TITLE
Bump unearth to newer version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ _Unreleased_
 
 - Removed the non functional `shell` command.  #602
 
+- Upgraded internal unearth dependency which resolved an issue where
+  `rye add tensorflow` would not work.  #614
+
 <!-- released start -->
 
 ## 0.21.0

--- a/rye/src/bootstrap.rs
+++ b/rye/src/bootstrap.rs
@@ -36,7 +36,7 @@ pub const SELF_PYTHON_TARGET_VERSION: PythonVersionRequest = PythonVersionReques
     suffix: None,
 };
 
-const SELF_VERSION: u64 = 9;
+const SELF_VERSION: u64 = 10;
 
 const SELF_REQUIREMENTS: &str = r#"
 build==1.0.3
@@ -52,7 +52,7 @@ pyproject_hooks==1.0.0
 requests==2.31.0
 tomli==2.0.1
 twine==4.0.2
-unearth==0.12.1
+unearth==0.14.0
 urllib3==2.0.7
 virtualenv==20.25.0
 ruff==0.1.14


### PR DESCRIPTION
Looks like upgrading unearth fixes an issue with some packages not being added correctly.

After update:

```
$ rye add tensorflow
Added tensorflow>=2.15.0 as regular dependency
```

Fixes #613