### PR TITLE
Use default toolchain from config when initializing a project

### DIFF
--- a/rye/src/cli/init.rs
+++ b/rye/src/cli/init.rs
@@ -297,11 +297,18 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
     let py = match cmd.py {
         Some(py) => PythonVersionRequest::from_str(&py)
             .map_err(|msg| anyhow!("invalid version: {}", msg))?,
-        None => match get_python_version_request_from_pyenv_pin(&dir) {
-            Some(ver) => ver,
-            None => PythonVersionRequest::from(get_latest_cpython_version()?),
+        None => {
+            if let Ok(default_toolchain) = cfg.default_toolchain() {
+                default_toolchain
+            } else {
+                match get_python_version_request_from_pyenv_pin(&dir) {
+                    Some(ver) => ver,
+                    None => PythonVersionRequest::from(get_latest_cpython_version()?),
+                }
+            }
         },
     };
+    
     if !cmd.no_pin
         && !VersionSpecifier::from_str(&requires_python)
             .map_err(|msg| anyhow!("invalid version specifier: {}", msg))?

--- a/rye/src/cli/init.rs
+++ b/rye/src/cli/init.rs
@@ -306,9 +306,8 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
                     None => PythonVersionRequest::from(get_latest_cpython_version()?),
                 }
             }
-        },
+        }
     };
-    
     if !cmd.no_pin
         && !VersionSpecifier::from_str(&requires_python)
             .map_err(|msg| anyhow!("invalid version specifier: {}", msg))?


### PR DESCRIPTION
When initializing a project, the current fallback is to get the latest CPython version, even if the user has a `default.toolchain` value specified in their rye configuration file.

This PR proposes a different sequence of checks: the default toolchain is used if available, then the version from pyenv if available, and lastly the latest CPython version.