### PR TITLE
Show sources in rye show and support inline tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ _Unreleased_
 - Rye now statically links `vcruntime` on Windows which no longer requires
   the vs redist to be installed.  #622
 
+- `rye show` now prints out which sources are configured for a project.  #631
+
 <!-- released start -->
 
 ## 0.21.0

--- a/rye/src/cli/show.rs
+++ b/rye/src/cli/show.rs
@@ -71,6 +71,22 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
         }
     }
 
+    match project.sources() {
+        Ok(mut sources) => {
+            sources.sort_by_cached_key(|x| (x.name != "default", x.name.to_string()));
+            echo!("configured sources:");
+            for source in sources {
+                echo!(
+                    "  {} ({}: {})",
+                    style(&source.name).cyan(),
+                    style(&source.ty).yellow(),
+                    style(&source.url).dim(),
+                );
+            }
+        }
+        Err(err) => echo!("invalid source config: {}", style(err).red()),
+    }
+
     Ok(())
 }
 

--- a/rye/src/config.rs
+++ b/rye/src/config.rs
@@ -11,6 +11,7 @@ use toml_edit::Document;
 use crate::platform::{get_app_dir, get_latest_cpython_version};
 use crate::pyproject::{BuildSystem, SourceRef, SourceRefType};
 use crate::sources::PythonVersionRequest;
+use crate::utils::toml;
 
 static CONFIG: Mutex<Option<Arc<Config>>> = Mutex::new(None);
 static AUTHOR_REGEX: Lazy<Regex> =
@@ -224,8 +225,9 @@ impl Config {
     pub fn sources(&self) -> Result<Vec<SourceRef>, Error> {
         let mut rv = Vec::new();
         let mut need_default = true;
-        if let Some(sources) = self.doc.get("sources").and_then(|x| x.as_array_of_tables()) {
+        if let Some(sources) = self.doc.get("sources").map(|x| toml::iter_tables(x)) {
             for source in sources {
+                let source = source.context("invalid value for source in config.toml")?;
                 let source_ref = SourceRef::from_toml_table(source)?;
                 if source_ref.name == "default" {
                     need_default = false;


### PR DESCRIPTION
Add support for inline tables for sources. Now the following two formats are equivalent:

```toml
[[tool.rye.sources]]
name = "test"
url = "https://test.pypi.org/simple/)"

[tool.rye]
sources = [
  { name = "test", url = "https://test.pypi.org/simple/)" }
]
```

Additionally `rye show` now spits out which sources are configured:

```
$ rye show
project: x
...
configured sources:
  default (index: https://pypi.org/simple/)
  test (index: https://test.pypi.org/simple/)
```

Fixes #485