### PR TITLE
No longer error on xattr removal if it fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ that were not yet released.
 
 _Unreleased_
 
+- When `behavior.venv-mark-sync-ignore` is set to `false` and the file system
+  does not support extended attributes, no longer will a warning be printed.  #633
+
 <!-- released start -->
 
 ## 0.22.0

--- a/rye/src/utils/mod.rs
+++ b/rye/src/utils/mod.rs
@@ -54,7 +54,8 @@ where
 }
 
 /// Given the path to a folder this adds or removes a cloud sync flag
-/// on the folder.
+/// on the folder.  Adding flags will return an error if it does not work,
+/// removing flags is silently ignored.
 ///
 /// Today this only supports dropbox and apple icloud.
 pub fn mark_path_sync_ignore(venv: &Path, mark_ignore: bool) -> Result<(), Error> {
@@ -64,7 +65,7 @@ pub fn mark_path_sync_ignore(venv: &Path, mark_ignore: bool) -> Result<(), Error
             if mark_ignore {
                 xattr::set(venv, flag, b"1")?;
             } else {
-                xattr::remove(venv, flag)?;
+                xattr::remove(venv, flag).ok();
             }
         }
     }


### PR DESCRIPTION
Today we error if xattr removal fails on a virtualenv. That's not ideal because it means the user always sees a warning on an unsupported file system, even if `behavior.venv-mark-sync-ignore` is disabled.

Refs #632