### PR TITLE
Only update venv cloud sync marker when creating virtualenvs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ _Unreleased_
 
 - Fixed a bug that caused warnings about unsupported operations to be shown on Linux. #634
 
+- The venv sync marker is now only updated when a new virtualenv is created.  #638
+
 <!-- released start -->
 
 ## 0.22.0

--- a/rye/src/sync.rs
+++ b/rye/src/sync.rs
@@ -159,7 +159,6 @@ pub fn sync(mut cmd: SyncOptions) -> Result<(), Error> {
         {
             echo!("Reusing already existing virtualenv");
         }
-        update_venv_sync_marker(output, &venv);
     } else {
         if output != CommandOutput::Quiet {
             echo!(


### PR DESCRIPTION
The cloud sync marker is now only updated when new virtualenvs are created.

Refs #632