### PR TITLE
Add token.txt to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target
 site
 __pycache__
 .idea
+token.txt


### PR DESCRIPTION
token.txt is used in find-donwloads.py. Let's include any file that is called token.txt, in case people run find-donwloads.py from within the repo.