### PR TITLE
Fix out of date Windows Developer Mode instructions

### DIFF
--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -38,11 +38,21 @@ support for symlinks is restricted to privileged accounts.  The reason for this 
 Symlinks were a late addition to Windows and some applications are not developed with
 them in mind which can cause misbehavior or in the worst case security issues in those
 applications.  Symlinks support however is enabled when the "developer mode" is activated
-on modern Windows versions.  Here is how you can enable it:
+on modern Windows versions.  
+
+Enabling "developer mode" has changed in later version of Windows. For older versions:
 
 1. Press ++windows+i++ to open the settings
 2. In the settings dialog click on "Privacy & security"
 3. In the "Security" section click on "For developers"
+4. Enable the toggle "Developer Mode"
+5. In the "Use developer features" dialog confirm by clicking "Yes".
+
+In more modern versions:
+
+1. Press ++windows+i++ to open the settings
+2. In the settings dialog click on "System"
+3. In the "System" section click on "For developers"
 4. Enable the toggle "Developer Mode"
 5. In the "Use developer features" dialog confirm by clicking "Yes".
 


### PR DESCRIPTION
I'm just installing Rye on my Windows 11 machine. I've noticed that the advice for enabling developer mode is out of date for later versions of Windows. 

The [FAQ doc](https://github.com/mitsuhiko/rye/blob/main/docs/guide/faq.md) states that developer mode can be enabled at:

Settings -> Privacy & security -> Security section -> For developers -> Toggle "Developer Mode".

In more modern versions of Windows 11, the steps are: 

Settings -> System -> For developers -> Toggle "Developer Mode".

See my attached screenshots and also the reply by Michael Odi to this [Microsoft support thread discussing developer options](https://answers.microsoft.com/en-us/windows/forum/all/cannot-see-for-developers-option-on-windows-11/20d0be5c-4554-4a14-a37a-5ade77b7be23).

![2024-02-12_10-30-54](https://github.com/mitsuhiko/rye/assets/1659754/1e2dbd71-c167-4d2d-984d-1204c00d8403)

![2024-02-12_10-31-44](https://github.com/mitsuhiko/rye/assets/1659754/f4ed6905-bd17-44b9-a946-68065c3c6972)

