### PR TITLE
Add --modify-path and --no-modify-path to self install

### DIFF
--- a/rye/src/cli/rye.rs
+++ b/rye/src/cli/rye.rs
@@ -617,6 +617,7 @@ fn perform_install(
 }
 
 /// Add rye to the users path.
+#[cfg_attr(windows, allow(unused_variables))]
 fn add_rye_to_path(mode: &InstallMode, shims: &Path, ask: bool) -> Result<(), Error> {
     let rye_home = env::var("RYE_HOME")
         .map(Cow::Owned)

--- a/rye/src/cli/rye.rs
+++ b/rye/src/cli/rye.rs
@@ -547,11 +547,26 @@ fn perform_install(
         prompt_for_default_toolchain(registered_toolchain.unwrap(), config_doc)?;
     }
 
+    add_rye_to_path(&mode, shims.as_path())?;
+
+    echo!();
+    echo!("{}", style("All done!").green());
+
+    config.save()?;
+
+    Ok(())
+}
+
+fn add_rye_to_path(mode: &InstallMode, shims: &Path) -> Result<(), Error> {
+    let rye_home = env::var("RYE_HOME")
+        .map(Cow::Owned)
+        .unwrap_or(Cow::Borrowed(DEFAULT_HOME));
+
     let rye_home = Path::new(&*rye_home);
     #[cfg(unix)]
     {
         if !env::split_paths(&env::var_os("PATH").unwrap())
-            .any(|x| same_file::is_same_file(x, &shims).unwrap_or(false))
+            .any(|x| same_file::is_same_file(x, shims).unwrap_or(false))
         {
             echo!();
             echo!(
@@ -602,12 +617,6 @@ fn perform_install(
         crate::utils::windows::add_to_programs(rye_home)?;
         crate::utils::windows::add_to_path(rye_home)?;
     }
-
-    echo!();
-    echo!("{}", style("All done!").green());
-
-    config.save()?;
-
     Ok(())
 }
 

--- a/rye/src/cli/rye.rs
+++ b/rye/src/cli/rye.rs
@@ -557,12 +557,16 @@ fn perform_install(
     Ok(())
 }
 
+/// Add rye to the users path.
 fn add_rye_to_path(mode: &InstallMode, shims: &Path) -> Result<(), Error> {
     let rye_home = env::var("RYE_HOME")
         .map(Cow::Owned)
         .unwrap_or(Cow::Borrowed(DEFAULT_HOME));
 
     let rye_home = Path::new(&*rye_home);
+    // For unices, we ask the user if they want rye to be added to PATH.
+    // If they choose to do so, we add the "env" script to .profile.
+    // See [`crate::utils::unix::add_to_path`].
     #[cfg(unix)]
     {
         if !env::split_paths(&env::var_os("PATH").unwrap())
@@ -612,6 +616,7 @@ fn add_rye_to_path(mode: &InstallMode, shims: &Path) -> Result<(), Error> {
             echo!("For more information read https://rye-up.com/guide/installation/");
         }
     }
+    // On Windows, we add the rye directory to the user's PATH unconditionally.
     #[cfg(windows)]
     {
         crate::utils::windows::add_to_programs(rye_home)?;


### PR DESCRIPTION
This is an RFC for how we handle skipping certain steps independent
from --yes being present. The PR adds the `--modify-path` and
`--no-modify-path` flag that can be used to turn off and on path
modification without prompting the user.  his allows people to do
self-installs such as `rye self install --yes --no-modify-path`.

The goal here is to get fine grained control over the install process
for headless/non-interactive installations. We use `--x`, `--no-x` style
flags inline with popular tools like curl, ripgrep, git, etc.

This should address https://github.com/mitsuhiko/rye/issues/620.
