### PR TITLE
Use default toolchain to install tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ _Unreleased_
 
 - Bump `uv` to 0.1.2.  #665
 
+- Use default toolchain to install tools.  #666
+
 <!-- released start -->
 
 ## 0.24.0

--- a/rye/src/cli/install.rs
+++ b/rye/src/cli/install.rs
@@ -5,6 +5,7 @@ use clap::Parser;
 use pep508_rs::Requirement;
 
 use crate::cli::add::ReqExtras;
+use crate::config::Config;
 use crate::installer::{install, resolve_local_requirement};
 use crate::sources::PythonVersionRequest;
 use crate::utils::CommandOutput;
@@ -53,15 +54,17 @@ pub fn execute(mut cmd: Args) -> Result<(), Error> {
 
     let py_ver: PythonVersionRequest = match cmd.python {
         Some(ref py) => py.parse()?,
-        None => PythonVersionRequest {
-            name: None,
-            arch: None,
-            os: None,
-            major: 3,
-            minor: None,
-            patch: None,
-            suffix: None,
-        },
+        None => Config::current()
+            .default_toolchain()
+            .unwrap_or(PythonVersionRequest {
+                name: None,
+                arch: None,
+                os: None,
+                major: 3,
+                minor: None,
+                patch: None,
+                suffix: None,
+            }),
     };
 
     install(


### PR DESCRIPTION
Currently only the latest toolchain will be used when installing tools, while a user may have set things up with a different one. This change uses the default toolchain, unless other options are provided on the command line.