### PR TITLE
Port rye add to uv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ _Unreleased_
 
 - Bump `uv` to 0.1.2.  #665
 
+- When `uv` is enabled, `rye add` now uses `uv` instead of `unearth`
+  internally.  #667
+
 <!-- released start -->
 
 ## 0.24.0

--- a/rye/src/cli/add.rs
+++ b/rye/src/cli/add.rs
@@ -450,7 +450,11 @@ fn resolve_requirements_with_uv(
     if output == CommandOutput::Quiet {
         cmd.arg("-q");
     }
-    let mut child = cmd.stdin(Stdio::piped()).stdout(Stdio::piped()).spawn()?;
+    let mut child = cmd
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
     let child_stdin = child.stdin.as_mut().unwrap();
     for requirement in &*requirements {
         writeln!(child_stdin, "{}", requirement)?;

--- a/rye/src/sources.rs
+++ b/rye/src/sources.rs
@@ -144,6 +144,17 @@ impl From<PythonVersionRequest> for Version {
     }
 }
 
+impl PythonVersion {
+    /// Returns a simplified format of the version request.
+    pub fn format_simple(&self) -> String {
+        use std::fmt::Write;
+        let mut rv = format!("{}", self.major);
+        write!(rv, ".{}", self.minor).unwrap();
+        write!(rv, ".{}", self.patch).unwrap();
+        rv
+    }
+}
+
 /// Internal descriptor for a python version request.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone)]
 pub struct PythonVersionRequest {


### PR DESCRIPTION
When `uv` is available, `rye add` now bypasses `unearth`. This leads to more consistent experiences.

At least for when `uv` is used, this should also fix #654 