### PR TITLE
Docs: add config setting for uv. CLI: Standardize Python Capitalization, refine some CLI messages

### DIFF
--- a/docs/guide/config.md
+++ b/docs/guide/config.md
@@ -81,6 +81,10 @@ force-rye-managed = false
 # virtual environments.
 global-python = false
 
+# When set to `true` enables experimental support of uv as a replacement
+# for pip-tools. Learn more about uv here: https://github.com/astral-sh/uv
+use-uv = false
+
 # Marks the managed .venv in a way that cloud based synchronization systems
 # like Dropbox and iCloud Files will not upload it.  This defaults to true
 # as a .venv in cloud storage typically does not make sense.  Set this to

--- a/rye/src/bootstrap.rs
+++ b/rye/src/bootstrap.rs
@@ -345,7 +345,7 @@ fn ensure_latest_self_toolchain(output: CommandOutput) -> Result<PythonVersion, 
     {
         if output != CommandOutput::Quiet {
             echo!(
-                "Found a compatible python version: {}",
+                "Found a compatible Python version: {}",
                 style(&version).cyan()
             );
         }
@@ -379,7 +379,7 @@ fn ensure_specific_self_toolchain(
     } else {
         if output != CommandOutput::Quiet {
             echo!(
-                "Found a compatible python version: {}",
+                "Found a compatible Python version: {}",
                 style(&toolchain_version).cyan()
             );
         }

--- a/rye/src/cli/fetch.rs
+++ b/rye/src/cli/fetch.rs
@@ -45,6 +45,6 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
         }
     };
 
-    fetch(&version, output).context("error while fetching python installation")?;
+    fetch(&version, output).context("error while fetching Python installation")?;
     Ok(())
 }

--- a/rye/src/cli/init.rs
+++ b/rye/src/cli/init.rs
@@ -307,7 +307,7 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
             .map_err(|msg| anyhow!("invalid version specifier: {}", msg))?
             .contains(&py.clone().into())
     {
-        warn!("conflicted python version with project's requires-python, will auto fix it.");
+        warn!("conflicted Python version with project's requires-python, will auto fix it.");
         requires_python = format!(">= {}.{}", py.major, py.minor.unwrap_or_default());
     }
 

--- a/rye/src/cli/rye.rs
+++ b/rye/src/cli/rye.rs
@@ -386,7 +386,7 @@ fn perform_install(
     if matches!(mode, InstallMode::AutoInstall) {
         echo!();
         echo!("Rye has detected that it's not installed on this computer yet and");
-        echo!("automatically started the installer for you.  For more information");
+        echo!("automatically started the installer for you. For more information");
         echo!(
             "read {}",
             style("https://rye-up.com/guide/installation/").yellow()
@@ -424,7 +424,7 @@ fn perform_install(
         warn!("your Windows configuration does not support symlinks.");
         echo!();
         echo!("It's strongly recommended that you enable developer mode in Windows to");
-        echo!("enable symlinks.  You need to enable this before continuing the setup.");
+        echo!("enable symlinks. You need to enable this before continuing the setup.");
         echo!(
             "Learn more at {}",
             style("https://rye-up.com/guide/faq/#windows-developer-mode").yellow()
@@ -594,7 +594,7 @@ fn perform_install(
                 );
                 echo!();
             }
-            echo!("For more information read https://mitsuhiko.github.io/rye/guide/installation");
+            echo!("For more information read https://rye-up.com/guide/installation/");
         }
     }
     #[cfg(windows)]

--- a/rye/src/cli/shim.rs
+++ b/rye/src/cli/shim.rs
@@ -236,7 +236,7 @@ fn get_shim_target(
             remove1 = true;
             (
                 PythonVersionRequest::from_str(rest)
-                    .context("invalid python version requested from command line")?,
+                    .context("invalid Python version requested from command line")?,
                 false,
             )
         } else if config.global_python() {
@@ -317,9 +317,14 @@ pub fn execute_shim(args: &[OsString]) -> Result<(), Error> {
             match spawn_shim(args)? {}
         } else if is_python_shim(&shim_name) {
             if pyproject.is_some() {
-                bail!("target python binary '{}' not found in project. Most likely running 'rye sync' will resolve this.", shim_name);
+                bail!("Target Python binary '{}' not found in project. Most likely running 'rye sync' will resolve this.", shim_name);
             } else {
-                bail!("target python binary '{}' not found. You're outside of a project, consider enabling global shims: https://rye-up.com/guide/shims/#global-shims", shim_name);
+                bail!(
+                    "Target Python binary '{}' not found.\nYou are currently outside of a project. \
+                    To resolve this, consider enabling global shims. \
+                    Global shims allow for a Rye-managed Python installation.\n\
+                    For more information: https://rye-up.com/guide/shims/#global-shims", shim_name
+                );
             }
         } else {
             bail!("target shim binary '{}' not found", shim_name);

--- a/rye/src/config.rs
+++ b/rye/src/config.rs
@@ -256,7 +256,7 @@ impl Config {
             .and_then(|x| x.as_bool())
             .unwrap_or(false);
         if yes && cfg!(windows) {
-            warn!("uv enabled in config but not supported on windows");
+            warn!("uv is enabled in the configuration, but this feature is not currently supported on Windows");
             false
         } else {
             yes

--- a/rye/src/pyproject.rs
+++ b/rye/src/pyproject.rs
@@ -1126,7 +1126,7 @@ fn resolve_intended_venv_python_version(
         .or_else(|| Config::current().default_toolchain().ok())
         .ok_or_else(|| {
             anyhow!(
-                "could not determine a target python version.  Define requires-python in \
+                "could not determine a target Python version.  Define requires-python in \
                  pyproject.toml or use a .python-version file"
             )
         })?;
@@ -1139,7 +1139,7 @@ fn resolve_intended_venv_python_version(
         Ok(latest)
     } else {
         Err(anyhow!(
-            "Unable to determine target virtualenv python version"
+            "Unable to determine target virtualenv Python version"
         ))
     }
 }

--- a/rye/src/sync.rs
+++ b/rye/src/sync.rs
@@ -132,7 +132,7 @@ pub fn sync(mut cmd: SyncOptions) -> Result<(), Error> {
             }
         } else if cmd.force {
             if cmd.output != CommandOutput::Quiet {
-                echo!("Forcing re-creation of non rye managed virtualenv");
+                echo!("Forcing re-creation of non-rye managed virtualenv");
             }
             recreate = true;
         } else if cmd.mode == SyncMode::PythonOnly {


### PR DESCRIPTION
- Docs: added how to enable the experimental use of `uv`
- Standardize Python capitalization across various CLI messages
- Aligned the CLI message when global shims are not activated with changes in #669 