### PR TITLE
Default to use opt-in behavior for `uv` during no-prompt installation

### DIFF
--- a/rye/src/cli/rye.rs
+++ b/rye/src/cli/rye.rs
@@ -446,14 +446,14 @@ fn perform_install(
         .get("behavior")
         .and_then(|x| x.get("use-uv"))
         .is_none()
-        && (matches!(mode, InstallMode::NoPrompts)
-            || dialoguer::Select::with_theme(tui_theme())
-                .with_prompt("Select the preferred package installer")
-                .item("pip-tools (slow but stable)")
-                .item("uv (quick but experimental)")
-                .default(0)
-                .interact()?
-                == 1)
+        && !matches!(mode, InstallMode::NoPrompts)
+        && dialoguer::Select::with_theme(tui_theme())
+            .with_prompt("Select the preferred package installer")
+            .item("pip-tools (slow but stable)")
+            .item("uv (quick but experimental)")
+            .default(0)
+            .interact()?
+            == 1
     {
         toml::ensure_table(config_doc, "behavior")["use-uv"] = toml_edit::value(true);
     }


### PR DESCRIPTION
Using `--yes` for avoiding prompts during installation, Rye will default to use `uv`. I'm not sure if this is intended.

```
rye on  cp-no-prompt-install is 📦 v1.0.0 via 🐍 v3.11.6 via 🦀 v1.76.0 
❯ rm -rf ~/.rye

rye on  cp-no-prompt-install is 📦 v1.0.0 via 🐍 v3.11.6 via 🦀 v1.76.0 
❯ curl -sSf https://rye-up.com/get | RYE_INSTALL_OPTION='--yes' bash
This script will automatically download and install rye (latest) for you.
######################################################################## 100.0%
Welcome to Rye!

This installer will install rye to /Users/chrispryer/.rye
This path can be changed by exporting the RYE_HOME environment variable.

Details:
  Rye Version: 0.24.0
  Platform: macos (aarch64)

Installed binary to /Users/chrispryer/.rye/shims/rye
Bootstrapping rye internals
Downloading cpython@3.12.1
Checking checksum
success: Downloaded cpython@3.12.1
Upgrading pip
Installing internal dependencies
Updated self-python installation at /Users/chrispryer/.rye/self

All done!

rye on  cp-no-prompt-install is 📦 v1.0.0 via 🐍 via 🦀 v1.76.0 took 13s 
❯ cat ~/.rye/config.toml 
[behavior]
use-uv = true
global-python = true
```

This was originally reported here https://github.com/mitsuhiko/rye/pull/657#issuecomment-1949461136.

Given that the default for the second condition is to use the global shims I didn't modify it, but the first condition (choosing a preferred package installer) the default is `pip-tools` -- which I think makes sense while `uv` is experimental for Rye.

With this change:

```
rye on  cp-no-prompt-install is 📦 v1.0.0 via 🐍 v3.11.6 via 🦀 v1.76.0 
❯ ./target/debug/rye self install --yes
Welcome to Rye!

This installer will install rye to /Users/chrispryer/.rye
This path can be changed by exporting the RYE_HOME environment variable.

Details:
  Rye Version: 0.25.0
  Platform: macos (aarch64)

Installed binary to /Users/chrispryer/.rye/shims/rye
Bootstrapping rye internals
Downloading cpython@3.12.1
Checking checksum
success: Downloaded cpython@3.12.1
Upgrading pip
Installing internal dependencies
Updated self-python installation at /Users/chrispryer/.rye/self

All done!

rye on  cp-no-prompt-install is 📦 v1.0.0 via 🐍 via 🦀 v1.76.0 took 20s 
❯ cat ~/.rye/config.toml 
[behavior]
global-python = true
```