### PR TITLE
partially revert config tests

### DIFF
--- a/rye/src/config.rs
+++ b/rye/src/config.rs
@@ -376,18 +376,6 @@ author = "John Doe <john@example.com>""#,
     }
 
     #[test]
-    fn test_http_proxy_env_override() {
-        let (cfg_path, _temp_dir) = setup_config("[proxy]\nhttp = 'http://proxy.example.com'");
-        std::env::set_var("http_proxy", "http://env-proxy.example.com");
-        let cfg = Config::from_path(&cfg_path).expect("Failed to load config");
-        assert_eq!(
-            cfg.http_proxy_url(),
-            Some("http://env-proxy.example.com".to_string())
-        );
-        std::env::remove_var("http_proxy"); // Clean up
-    }
-
-    #[test]
     fn test_sources_default_inclusion() {
         let (cfg_path, _temp_dir) = setup_config("");
         let cfg = Config::from_path(&cfg_path).expect("Failed to load config");


### PR DESCRIPTION
45ca7b6a1d74441a0aaac2917ba15b8c3583eb00 introduces tests. Some of the tests rely on the presence or absence of the http_proxy env variable respectively. However as tests are run in parallel and env variables are a global program state, this is not safe. We remove the test relying on env variables for now, as it cause random failures in CI.

- **partially revert 45ca7b6a1d74441a0aaac2917ba15b8c3583eb00**
