### PR TITLE
Remove unused ARCH argument from fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ _Unreleased_
 
 - `uv` can now also be enabled on windows.  #675
 
+- Removed the unsupported and un-used `arch` parameter from `fetch`.  #681
+
 <!-- released start -->
 
 ## 0.24.0

--- a/docs/guide/commands/fetch.md
+++ b/docs/guide/commands/fetch.md
@@ -29,10 +29,6 @@ success: Downloaded cpython@3.8.17
 
     If no version is provided, the requested version will be fetched.
 
-* `[ARCH]`: Overrides the architecture to fetch.
-
-    When a non native architecture is fetched, the toolchain is installed under an alias.
-    
 ## Options
 
 * `-v, --verbose`: Enables verbose diagnostics

--- a/rye/src/cli/fetch.rs
+++ b/rye/src/cli/fetch.rs
@@ -15,11 +15,6 @@ pub struct Args {
     ///
     /// If no version is provided, the requested version will be fetched.
     version: Option<String>,
-    /// Overrides the architecture to fetch.
-    ///
-    /// When a non native architecture is fetched, the toolchain is
-    /// installed under an alias.
-    arch: Option<String>,
     /// Enables verbose diagnostics.
     #[arg(short, long)]
     verbose: bool,


### PR DESCRIPTION
The arch and os are provided in the version argument: `cpython-x86_64@3.11`