### PR TITLE
Add suffix to PythonVersionRequest display

### DIFF
--- a/rye/src/sources.rs
+++ b/rye/src/sources.rs
@@ -277,6 +277,9 @@ impl fmt::Display for PythonVersionRequest {
             write!(f, ".{}", minor)?;
             if let Some(ref patch) = self.patch {
                 write!(f, ".{}", patch)?;
+                if let Some(ref suffix) = self.suffix {
+                    write!(f, ".{}", suffix)?;
+                }
             }
         }
         Ok(())


### PR DESCRIPTION
Before:
```
❯ rye fetch cpython@3.11.7.lto
error: error while fetching python installation

Caused by:
    unknown version cpython@3.11.7
```

After:
```
❯ cargo run --quiet fetch cpython@3.11.7.lto
error: error while fetching Python installation

Caused by:
    unknown version cpython@3.11.7.lto
```