### PR TITLE
Added basic tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,6 +811,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fslock"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1059,6 +1069,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d64600be34b2fcfc267740a243fa7744441bb4947a619ac4e5bb6507f35fbfc"
+dependencies = [
+ "console",
+ "lazy_static",
+ "linked-hash-map",
+ "regex",
+ "serde",
+ "similar",
+ "yaml-rust",
+]
+
+[[package]]
+name = "insta-cmd"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809d3023d1d6e8d5c2206f199251f75cb26180e41f18cb0f22dd119161cb5127"
+dependencies = [
+ "insta",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1151,6 +1187,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1806,11 +1848,14 @@ dependencies = [
  "decompress",
  "dialoguer",
  "flate2",
+ "fslock",
  "git-testament",
  "globset",
  "hex",
  "home",
  "indicatif",
+ "insta",
+ "insta-cmd",
  "junction",
  "license",
  "memchr",
@@ -2004,6 +2049,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "similar"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32fea41aca09ee824cc9724996433064c89f7777e60762749a4170a14abbfa21"
 
 [[package]]
 name = "slug"
@@ -2739,6 +2790,15 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "rustix",
+]
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]

--- a/rye/Cargo.toml
+++ b/rye/Cargo.toml
@@ -71,3 +71,8 @@ winreg = "0.52.0"
 
 [target."cfg(windows)".build-dependencies]
 static_vcruntime = "2.0.0"
+
+[dev-dependencies]
+fslock = "0.2.1"
+insta = { version = "1.34.0", features = ["filters"] }
+insta-cmd = "0.4.0"

--- a/rye/src/cli/add.rs
+++ b/rye/src/cli/add.rs
@@ -16,6 +16,7 @@ use crate::config::Config;
 use crate::consts::VENV_BIN;
 use crate::pyproject::{BuildSystem, DependencyKind, ExpandedSources, PyProject};
 use crate::sources::PythonVersion;
+use crate::sync::{sync, SyncOptions};
 use crate::utils::{format_requirement, set_proxy_variables, CommandOutput};
 
 const PACKAGE_FINDER_SCRIPT: &str = r#"
@@ -251,6 +252,8 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
 
     if !cmd.excluded {
         if Config::current().use_uv() {
+            sync(SyncOptions::python_only().pyproject(None))
+                .context("failed to sync ahead of add")?;
             resolve_requirements_with_uv(
                 &pyproject_toml,
                 &self_venv,

--- a/rye/src/lock.rs
+++ b/rye/src/lock.rs
@@ -4,7 +4,7 @@ use std::io::{BufWriter, Write};
 use std::path::Path;
 use std::process::Command;
 use std::sync::Arc;
-use std::{fmt, fs};
+use std::{env, fmt, fs};
 
 use anyhow::{anyhow, bail, Context, Error};
 use minijinja::render;
@@ -330,6 +330,10 @@ fn generate_lockfile(
             cmd.arg("--verbose");
         } else if output == CommandOutput::Quiet {
             cmd.arg("-q");
+        }
+        // this primarily exists for testing
+        if let Ok(dt) = env::var("__RYE_UV_EXCLUDE_NEWER") {
+            cmd.arg("--exclude-newer").arg(dt);
         }
         cmd
     } else {

--- a/rye/tests/common/mod.rs
+++ b/rye/tests/common/mod.rs
@@ -7,8 +7,12 @@ use insta_cmd::get_cargo_bin;
 use tempfile::TempDir;
 
 pub const INSTA_FILTERS: &[(&str, &str)] = &[
+    // general test folders
     (r"/.*?/\.rye-tests---[^/]+/", "[TEMP_PATH]/"),
+    // macos test folder
     (r"/var/folders/\S+?/T/\S+", "[TEMP_FILE]"),
+    // linux test folders
+    (r"/tmp/\.tmp\S+", "[TEMP_FILE]"),
     (r" in \d+(ms|s)\b", " in [EXECUTION_TIME]"),
     (r"\\([\w\d])", "/$1"),
     (r"rye.exe", "rye"),

--- a/rye/tests/common/mod.rs
+++ b/rye/tests/common/mod.rs
@@ -6,6 +6,9 @@ use std::process::Command;
 use insta_cmd::get_cargo_bin;
 use tempfile::TempDir;
 
+// Exclude any packages uploaded after this date.
+pub static EXCLUDE_NEWER: &str = "2023-11-18T12:00:00Z";
+
 pub const INSTA_FILTERS: &[(&str, &str)] = &[
     // general temp folders
     (
@@ -118,6 +121,7 @@ impl Space {
         let mut rv = Command::new(cmd);
         rv.env("RYE_HOME", self.rye_home().as_os_str());
         rv.env("UV_CACHE_DIR", self.tempdir.path().join("uv-cache"));
+        rv.env("__RYE_UV_EXCLUDE_NEWER", EXCLUDE_NEWER);
         rv.current_dir(self.project_path());
         rv
     }

--- a/rye/tests/common/mod.rs
+++ b/rye/tests/common/mod.rs
@@ -7,14 +7,19 @@ use insta_cmd::get_cargo_bin;
 use tempfile::TempDir;
 
 pub const INSTA_FILTERS: &[(&str, &str)] = &[
-    // general test folders
-    (r"/.*?/\.rye-tests---[^/]+/", "[TEMP_PATH]/"),
-    // macos test folder
+    // general temp folders
+    (
+        r"(\bA-Z:)?[\\/].*?[\\/]\.rye-tests---[^\\/]+[\\/]",
+        "[TEMP_PATH]/",
+    ),
+    // macos temp folder
     (r"/var/folders/\S+?/T/\S+", "[TEMP_FILE]"),
-    // linux test folders
+    // linux temp folders
     (r"/tmp/\.tmp\S+", "[TEMP_FILE]"),
+    // windows temp folders
+    (r"\b[A-Z]:/.*/Local/Temp/\S+", "[TEMP_FILE]"),
     (r" in \d+(ms|s)\b", " in [EXECUTION_TIME]"),
-    (r"\\([\w\d])", "/$1"),
+    (r"\\([\w\d.])", "/$1"),
     (r"rye.exe", "rye"),
 ];
 

--- a/rye/tests/common/mod.rs
+++ b/rye/tests/common/mod.rs
@@ -1,0 +1,154 @@
+use std::ffi::OsStr;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use insta_cmd::get_cargo_bin;
+use tempfile::TempDir;
+
+pub const INSTA_FILTERS: &[(&str, &str)] = &[
+    (r"/.*?/\.rye-tests---[^/]+/", "[TEMP_PATH]/"),
+    (r"/var/folders/\S+?/T/\S+", "[TEMP_FILE]"),
+    (r" in \d+(ms|s)\b", " in [EXECUTION_TIME]"),
+    (r"\\([\w\d])", "/$1"),
+    (r"rye.exe", "rye"),
+];
+
+fn marked_tempdir() -> TempDir {
+    TempDir::with_prefix(".rye-tests---").unwrap()
+}
+
+fn bootstrap_test_rye() -> PathBuf {
+    let home = get_cargo_bin("rye").parent().unwrap().join("rye-test-home");
+    fs::create_dir_all(&home).ok();
+    let lock_path = home.join("lock");
+    let mut lock = fslock::LockFile::open(&lock_path).unwrap();
+    lock.lock().unwrap();
+
+    // write config
+    let config_file = home.join("config.toml");
+    if !config_file.is_file() {
+        fs::write(
+            home.join("config.toml"),
+            r#"
+[behavior]
+use-uv = true
+
+[default]
+toolchain = "cpython@3.12.1"
+"#,
+        )
+        .unwrap();
+    }
+
+    // fetch the most important interpreters
+    for version in ["cpython@3.8.17", "cpython@3.11.7", "cpython@3.12.1"] {
+        if home.join("py").join(version).is_dir() {
+            continue;
+        }
+        let status = Command::new(get_bin())
+            .env("RYE_HOME", &home)
+            .arg("fetch")
+            .arg(version)
+            .status()
+            .unwrap();
+        assert!(status.success());
+    }
+
+    // make a dummy project to boostrap it
+    if !home.join("self").is_dir() {
+        let t = marked_tempdir();
+        Command::new(get_bin())
+            .env("RYE_HOME", &home)
+            .current_dir(t.path())
+            .arg("init")
+            .arg("--name=test-project")
+            .status()
+            .unwrap();
+        Command::new(get_bin())
+            .env("RYE_HOME", &home)
+            .current_dir(t.path())
+            .arg("sync")
+            .status()
+            .unwrap();
+    }
+
+    lock.unlock().unwrap();
+
+    home
+}
+
+pub fn get_bin() -> PathBuf {
+    get_cargo_bin("rye")
+}
+
+pub struct Space {
+    #[allow(unused)]
+    tempdir: TempDir,
+    rye_home: PathBuf,
+    project_dir: PathBuf,
+}
+
+impl Space {
+    pub fn new() -> Space {
+        let tempdir = marked_tempdir();
+        let project_dir = tempdir.path().join("project");
+        let rye_home = bootstrap_test_rye();
+        fs::create_dir_all(&project_dir).unwrap();
+        Space {
+            tempdir,
+            project_dir,
+            rye_home,
+        }
+    }
+
+    pub fn cmd<S>(&self, cmd: S) -> Command
+    where
+        S: AsRef<OsStr>,
+    {
+        let mut rv = Command::new(cmd);
+        rv.env("RYE_HOME", self.rye_home().as_os_str());
+        rv.current_dir(self.project_path());
+        rv
+    }
+
+    pub fn rye_cmd(&self) -> Command {
+        self.cmd(get_bin())
+    }
+
+    pub fn init(&self, name: &str) {
+        let status = self
+            .cmd(get_bin())
+            .arg("init")
+            .arg("--name")
+            .arg(name)
+            .arg("-q")
+            .current_dir(self.project_path())
+            .status()
+            .unwrap();
+        assert!(status.success());
+    }
+
+    pub fn rye_home(&self) -> &Path {
+        &self.rye_home
+    }
+
+    pub fn project_path(&self) -> &Path {
+        &self.project_dir
+    }
+}
+
+#[allow(unused_macros)]
+macro_rules! rye_cmd_snapshot {
+    ($cmd:expr, @$snapshot:literal) => {{
+        let mut settings = insta::Settings::clone_current();
+        for (matcher, replacement) in $crate::common::INSTA_FILTERS {
+            settings.add_filter(matcher, *replacement);
+        }
+        let _guard = settings.bind_to_scope();
+        insta_cmd::assert_cmd_snapshot!($cmd, @$snapshot);
+    }};
+}
+
+#[allow(unused_imports)]
+pub(crate) use rye_cmd_snapshot;

--- a/rye/tests/common/mod.rs
+++ b/rye/tests/common/mod.rs
@@ -55,7 +55,7 @@ toolchain = "cpython@3.12.1"
         assert!(status.success());
     }
 
-    // make a dummy project to boostrap it
+    // make a dummy project to bootstrap it
     if !home.join("self").is_dir() {
         let t = marked_tempdir();
         Command::new(get_bin())

--- a/rye/tests/common/mod.rs
+++ b/rye/tests/common/mod.rs
@@ -9,7 +9,7 @@ use tempfile::TempDir;
 pub const INSTA_FILTERS: &[(&str, &str)] = &[
     // general temp folders
     (
-        r"(\bA-Z:)?[\\/].*?[\\/]\.rye-tests---[^\\/]+[\\/]",
+        r"(\b[A-Z]:)?[\\/].*?[\\/]\.rye-tests---[^\\/]+[\\/]",
         "[TEMP_PATH]/",
     ),
     // macos temp folder
@@ -17,7 +17,7 @@ pub const INSTA_FILTERS: &[(&str, &str)] = &[
     // linux temp folders
     (r"/tmp/\.tmp\S+", "[TEMP_FILE]"),
     // windows temp folders
-    (r"\b[A-Z]:/.*/Local/Temp/\S+", "[TEMP_FILE]"),
+    (r"\b[A-Z]:\\.*\\Local\\Temp\\\S+", "[TEMP_FILE]"),
     (r" in (\d+\.)?\d+(ms|s)\b", " in [EXECUTION_TIME]"),
     (r"\\([\w\d.])", "/$1"),
     (r"rye.exe", "rye"),

--- a/rye/tests/common/mod.rs
+++ b/rye/tests/common/mod.rs
@@ -18,7 +18,7 @@ pub const INSTA_FILTERS: &[(&str, &str)] = &[
     (r"/tmp/\.tmp\S+", "[TEMP_FILE]"),
     // windows temp folders
     (r"\b[A-Z]:/.*/Local/Temp/\S+", "[TEMP_FILE]"),
-    (r" in \d+(ms|s)\b", " in [EXECUTION_TIME]"),
+    (r" in (\d+\.)?\d+(ms|s)\b", " in [EXECUTION_TIME]"),
     (r"\\([\w\d.])", "/$1"),
     (r"rye.exe", "rye"),
 ];
@@ -117,6 +117,7 @@ impl Space {
     {
         let mut rv = Command::new(cmd);
         rv.env("RYE_HOME", self.rye_home().as_os_str());
+        rv.env("UV_CACHE_DIR", self.tempdir.path().join("uv-cache"));
         rv.current_dir(self.project_path());
         rv
     }

--- a/rye/tests/test_sync.rs
+++ b/rye/tests/test_sync.rs
@@ -67,10 +67,10 @@ fn test_add_and_sync() {
     Installed 8 packages in [EXECUTION_TIME]
      + blinker==1.7.0
      + click==8.1.7
-     + flask==3.0.2
+     + flask==3.0.0
      + itsdangerous==2.1.2
-     + jinja2==3.1.3
-     + markupsafe==2.1.5
+     + jinja2==3.1.2
+     + markupsafe==2.1.3
      + my-project==0.1.0 (from file:[TEMP_PATH]/project)
      + werkzeug==3.0.1
     "###);

--- a/rye/tests/test_sync.rs
+++ b/rye/tests/test_sync.rs
@@ -34,12 +34,14 @@ fn test_empty_sync() {
 fn test_add_and_sync() {
     let space = Space::new();
     space.init("my-project");
-    rye_cmd_snapshot!(space.rye_cmd().arg("add").arg("flask==3.0.0"), @r###"
+    // add colorama to ensure we have this as a dependency on all platforms
+    rye_cmd_snapshot!(space.rye_cmd().arg("add").arg("flask==3.0.0").arg("colorama"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
     Initializing new virtualenv in [TEMP_PATH]/project/.venv
     Python version: cpython@3.12.1
+    Added colorama>=0.4.6 as regular dependency
     Added flask>=3.0.0 as regular dependency
 
     ----- stderr -----
@@ -57,16 +59,17 @@ fn test_add_and_sync() {
     ----- stderr -----
     warning: Requirements file [TEMP_FILE] does not contain any dependencies
     Built 1 editable in [EXECUTION_TIME]
-    Resolved 8 packages in [EXECUTION_TIME]
+    Resolved 9 packages in [EXECUTION_TIME]
     warning: Requirements file [TEMP_FILE] does not contain any dependencies
     Built 1 editable in [EXECUTION_TIME]
-    Resolved 8 packages in [EXECUTION_TIME]
+    Resolved 9 packages in [EXECUTION_TIME]
     Built 1 editable in [EXECUTION_TIME]
-    Resolved 7 packages in [EXECUTION_TIME]
-    Downloaded 7 packages in [EXECUTION_TIME]
-    Installed 8 packages in [EXECUTION_TIME]
+    Resolved 8 packages in [EXECUTION_TIME]
+    Downloaded 8 packages in [EXECUTION_TIME]
+    Installed 9 packages in [EXECUTION_TIME]
      + blinker==1.7.0
      + click==8.1.7
+     + colorama==0.4.6
      + flask==3.0.0
      + itsdangerous==2.1.2
      + jinja2==3.1.2

--- a/rye/tests/test_sync.rs
+++ b/rye/tests/test_sync.rs
@@ -1,0 +1,75 @@
+use crate::common::{rye_cmd_snapshot, Space};
+
+mod common;
+
+#[test]
+fn test_empty_sync() {
+    let space = Space::new();
+    space.init("my-project");
+    rye_cmd_snapshot!(space.rye_cmd().arg("sync"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Initializing new virtualenv in [TEMP_PATH]/project/.venv
+    Python version: cpython@3.12.1
+    Generating production lockfile: [TEMP_PATH]/project/requirements.lock
+    Generating dev lockfile: [TEMP_PATH]/project/requirements-dev.lock
+    Installing dependencies
+    Done!
+
+    ----- stderr -----
+    warning: Requirements file [TEMP_FILE] does not contain any dependencies
+    Built 1 editable in [EXECUTION_TIME]
+    Resolved 1 package in [EXECUTION_TIME]
+    warning: Requirements file [TEMP_FILE] does not contain any dependencies
+    Built 1 editable in [EXECUTION_TIME]
+    Resolved 1 package in [EXECUTION_TIME]
+    Built 1 editable in [EXECUTION_TIME]
+    Installed 1 package in [EXECUTION_TIME]
+     + my-project==0.1.0 (from file:[TEMP_PATH]/project)
+    "###);
+}
+
+#[test]
+fn test_add_and_sync() {
+    let space = Space::new();
+    space.init("my-project");
+    rye_cmd_snapshot!(space.rye_cmd().arg("add").arg("flask==3.0.0"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Initializing new virtualenv in [TEMP_PATH]/project/.venv
+    Python version: cpython@3.12.1
+    Added flask>=3.0.0 as regular dependency
+
+    ----- stderr -----
+    "###);
+    rye_cmd_snapshot!(space.rye_cmd().arg("sync"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Reusing already existing virtualenv
+    Generating production lockfile: [TEMP_PATH]/project/requirements.lock
+    Generating dev lockfile: [TEMP_PATH]/project/requirements-dev.lock
+    Installing dependencies
+    Done!
+
+    ----- stderr -----
+    warning: Requirements file [TEMP_FILE] does not contain any dependencies
+    Built 1 editable in [EXECUTION_TIME]
+    Resolved 8 packages in [EXECUTION_TIME]
+    warning: Requirements file [TEMP_FILE] does not contain any dependencies
+    Built 1 editable in [EXECUTION_TIME]
+    Resolved 8 packages in [EXECUTION_TIME]
+    Built 1 editable in [EXECUTION_TIME]
+    Installed 8 packages in [EXECUTION_TIME]
+     + blinker==1.7.0
+     + click==8.1.7
+     + flask==3.0.2
+     + itsdangerous==2.1.2
+     + jinja2==3.1.3
+     + markupsafe==2.1.5
+     + my-project==0.1.0 (from file:[TEMP_PATH]/project)
+     + werkzeug==3.0.1
+    "###);
+}

--- a/rye/tests/test_sync.rs
+++ b/rye/tests/test_sync.rs
@@ -62,6 +62,8 @@ fn test_add_and_sync() {
     Built 1 editable in [EXECUTION_TIME]
     Resolved 8 packages in [EXECUTION_TIME]
     Built 1 editable in [EXECUTION_TIME]
+    Resolved 7 packages in [EXECUTION_TIME]
+    Downloaded 7 packages in [EXECUTION_TIME]
     Installed 8 packages in [EXECUTION_TIME]
      + blinker==1.7.0
      + click==8.1.7


### PR DESCRIPTION
This adds the first two snapshot tests for rye. These tests won't work for all platforms yet.

* [x] normalize paths for windows
* [x] detect temp folders on linux
* [x] detect temp folders on windows
* [x] figure something out for caches for better stability
* [x] implement `--exclude-newer` with hardcoded date for resolver related stuff for stable snapshots
