### PR TITLE
Set ruff cache dir to workspace root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ _Unreleased_
 
 - Fixed the `-q` parameter not working for the `init` command.  #686
 
+- Configure the ruff cache directory to be located within the workspace root. #689
+
 <!-- released start -->
 
 ## 0.24.0

--- a/rye/src/cli/fmt.rs
+++ b/rye/src/cli/fmt.rs
@@ -1,89 +1,25 @@
-use std::ffi::OsString;
-use std::path::PathBuf;
-use std::process::Command;
-
 use anyhow::Error;
 use clap::Parser;
 
-use crate::bootstrap::ensure_self_venv;
-use crate::consts::VENV_BIN;
-use crate::pyproject::{locate_projects, PyProject};
-use crate::utils::{CommandOutput, QuietExit};
+use crate::utils::ruff;
 
 /// Run the code formatter on the project.
 ///
 /// This invokes ruff in format mode.
 #[derive(Parser, Debug)]
 pub struct Args {
-    /// List of files or directories to format
-    paths: Vec<PathBuf>,
-    /// Format all packages
-    #[arg(short, long)]
-    all: bool,
-    /// Format a specific package
-    #[arg(short, long)]
-    package: Vec<String>,
-    /// Use this pyproject.toml file
-    #[arg(long, value_name = "PYPROJECT_TOML")]
-    pyproject: Option<PathBuf>,
+    #[command(flatten)]
+    ruff: ruff::RuffArgs,
     /// Run format in check mode
     #[arg(long)]
     check: bool,
-    /// Enables verbose diagnostics.
-    #[arg(short, long)]
-    verbose: bool,
-    /// Turns off all output.
-    #[arg(short, long, conflicts_with = "verbose")]
-    quiet: bool,
-    /// Extra arguments to the formatter
-    #[arg(last = true)]
-    extra_args: Vec<OsString>,
 }
 
 pub fn execute(cmd: Args) -> Result<(), Error> {
-    let project = PyProject::load_or_discover(cmd.pyproject.as_deref())?;
-    let output = CommandOutput::from_quiet_and_verbose(cmd.quiet, cmd.verbose);
-    let venv = ensure_self_venv(output)?;
-    let ruff = venv.join(VENV_BIN).join("ruff");
-
-    let mut ruff_cmd = Command::new(ruff);
-    ruff_cmd.env(
-        "RUFF_CACHE_DIR",
-        project.workspace_path().join(".ruff_cache").as_os_str(),
-    );
-    ruff_cmd.arg("format");
-    match output {
-        CommandOutput::Normal => {}
-        CommandOutput::Verbose => {
-            ruff_cmd.arg("--verbose");
-        }
-        CommandOutput::Quiet => {
-            ruff_cmd.arg("-q");
-        }
-    }
-
+    let mut args = Vec::new();
+    args.push("format");
     if cmd.check {
-        ruff_cmd.arg("--check");
+        args.push("--check");
     }
-    ruff_cmd.args(cmd.extra_args);
-
-    ruff_cmd.arg("--");
-    if cmd.paths.is_empty() {
-        let projects = locate_projects(project, cmd.all, &cmd.package[..])?;
-        for project in projects {
-            ruff_cmd.arg(project.root_path().as_os_str());
-        }
-    } else {
-        for file in cmd.paths {
-            ruff_cmd.arg(file.as_os_str());
-        }
-    }
-
-    let status = ruff_cmd.status()?;
-    if !status.success() {
-        let code = status.code().unwrap_or(1);
-        Err(QuietExit(code).into())
-    } else {
-        Ok(())
-    }
+    ruff::execute_ruff(cmd.ruff, &args)
 }

--- a/rye/src/cli/fmt.rs
+++ b/rye/src/cli/fmt.rs
@@ -47,7 +47,10 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
     let ruff = venv.join(VENV_BIN).join("ruff");
 
     let mut ruff_cmd = Command::new(ruff);
-    ruff_cmd.env("RUFF_CACHE_DIR", project.workspace_path().join(".ruff_cache").as_os_str());
+    ruff_cmd.env(
+        "RUFF_CACHE_DIR",
+        project.workspace_path().join(".ruff_cache").as_os_str(),
+    );
     ruff_cmd.arg("format");
     match output {
         CommandOutput::Normal => {}

--- a/rye/src/cli/fmt.rs
+++ b/rye/src/cli/fmt.rs
@@ -47,6 +47,7 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
     let ruff = venv.join(VENV_BIN).join("ruff");
 
     let mut ruff_cmd = Command::new(ruff);
+    ruff_cmd.env("RUFF_CACHE_DIR", project.workspace_path().join(".ruff_cache").as_os_str());
     ruff_cmd.arg("format");
     match output {
         CommandOutput::Normal => {}

--- a/rye/src/cli/lint.rs
+++ b/rye/src/cli/lint.rs
@@ -47,7 +47,10 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
     let ruff = venv.join(VENV_BIN).join("ruff");
 
     let mut ruff_cmd = Command::new(ruff);
-    ruff_cmd.env("RUFF_CACHE_DIR", project.workspace_path().join(".ruff_cache").as_os_str());
+    ruff_cmd.env(
+        "RUFF_CACHE_DIR",
+        project.workspace_path().join(".ruff_cache").as_os_str(),
+    );
     ruff_cmd.arg("check");
     match output {
         CommandOutput::Normal => {}

--- a/rye/src/cli/lint.rs
+++ b/rye/src/cli/lint.rs
@@ -1,89 +1,25 @@
-use std::ffi::OsString;
-use std::path::PathBuf;
-use std::process::Command;
-
 use anyhow::Error;
 use clap::Parser;
 
-use crate::bootstrap::ensure_self_venv;
-use crate::consts::VENV_BIN;
-use crate::pyproject::{locate_projects, PyProject};
-use crate::utils::{CommandOutput, QuietExit};
+use crate::utils::ruff;
 
 /// Run the linter on the project.
 ///
 /// This invokes ruff in lint mode.
 #[derive(Parser, Debug)]
 pub struct Args {
-    /// List of files or directories to lint
-    paths: Vec<PathBuf>,
-    /// Lint all packages
-    #[arg(short, long)]
-    all: bool,
-    /// Lint a specific package
-    #[arg(short, long)]
-    package: Vec<String>,
-    /// Use this pyproject.toml file
-    #[arg(long, value_name = "PYPROJECT_TOML")]
-    pyproject: Option<PathBuf>,
+    #[command(flatten)]
+    ruff: ruff::RuffArgs,
     /// Apply fixes.
     #[arg(long)]
     fix: bool,
-    /// Enables verbose diagnostics.
-    #[arg(short, long)]
-    verbose: bool,
-    /// Turns off all output.
-    #[arg(short, long, conflicts_with = "verbose")]
-    quiet: bool,
-    /// Extra arguments to the linter
-    #[arg(last = true)]
-    extra_args: Vec<OsString>,
 }
 
 pub fn execute(cmd: Args) -> Result<(), Error> {
-    let project = PyProject::load_or_discover(cmd.pyproject.as_deref())?;
-    let output = CommandOutput::from_quiet_and_verbose(cmd.quiet, cmd.verbose);
-    let venv = ensure_self_venv(output)?;
-    let ruff = venv.join(VENV_BIN).join("ruff");
-
-    let mut ruff_cmd = Command::new(ruff);
-    ruff_cmd.env(
-        "RUFF_CACHE_DIR",
-        project.workspace_path().join(".ruff_cache").as_os_str(),
-    );
-    ruff_cmd.arg("check");
-    match output {
-        CommandOutput::Normal => {}
-        CommandOutput::Verbose => {
-            ruff_cmd.arg("--verbose");
-        }
-        CommandOutput::Quiet => {
-            ruff_cmd.arg("-q");
-        }
-    }
-
+    let mut args = Vec::new();
+    args.push("check");
     if cmd.fix {
-        ruff_cmd.arg("--fix");
+        args.push("--fix");
     }
-    ruff_cmd.args(cmd.extra_args);
-
-    ruff_cmd.arg("--");
-    if cmd.paths.is_empty() {
-        let projects = locate_projects(project, cmd.all, &cmd.package[..])?;
-        for project in projects {
-            ruff_cmd.arg(project.root_path().as_os_str());
-        }
-    } else {
-        for file in cmd.paths {
-            ruff_cmd.arg(file.as_os_str());
-        }
-    }
-
-    let status = ruff_cmd.status()?;
-    if !status.success() {
-        let code = status.code().unwrap_or(1);
-        Err(QuietExit(code).into())
-    } else {
-        Ok(())
-    }
+    ruff::execute_ruff(cmd.ruff, &args)
 }

--- a/rye/src/cli/lint.rs
+++ b/rye/src/cli/lint.rs
@@ -47,6 +47,7 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
     let ruff = venv.join(VENV_BIN).join("ruff");
 
     let mut ruff_cmd = Command::new(ruff);
+    ruff_cmd.env("RUFF_CACHE_DIR", project.workspace_path().join(".ruff_cache").as_os_str());
     ruff_cmd.arg("check");
     match output {
         CommandOutput::Normal => {}

--- a/rye/src/utils/mod.rs
+++ b/rye/src/utils/mod.rs
@@ -34,6 +34,7 @@ pub(crate) mod windows;
 #[cfg(unix)]
 pub(crate) mod unix;
 
+pub(crate) mod ruff;
 pub(crate) mod toml;
 
 #[cfg(windows)]

--- a/rye/src/utils/ruff.rs
+++ b/rye/src/utils/ruff.rs
@@ -1,0 +1,82 @@
+use std::env;
+use std::ffi::OsString;
+use std::path::PathBuf;
+use std::process::Command;
+
+use anyhow::Error;
+use clap::Parser;
+
+use crate::bootstrap::ensure_self_venv;
+use crate::consts::VENV_BIN;
+use crate::pyproject::{locate_projects, PyProject};
+use crate::utils::{CommandOutput, QuietExit};
+
+#[derive(Parser, Debug)]
+pub struct RuffArgs {
+    /// List of files or directories to limit the operation to
+    paths: Vec<PathBuf>,
+    /// Perform the operation on all packages
+    #[arg(short, long)]
+    all: bool,
+    /// Perform the operation on a specific package
+    #[arg(short, long)]
+    package: Vec<String>,
+    /// Use this pyproject.toml file
+    #[arg(long, value_name = "PYPROJECT_TOML")]
+    pyproject: Option<PathBuf>,
+    /// Enables verbose diagnostics.
+    #[arg(short, long)]
+    verbose: bool,
+    /// Turns off all output.
+    #[arg(short, long, conflicts_with = "verbose")]
+    quiet: bool,
+    /// Extra arguments to ruff
+    #[arg(last = true)]
+    extra_args: Vec<OsString>,
+}
+
+pub fn execute_ruff(args: RuffArgs, extra_args: &[&str]) -> Result<(), Error> {
+    let project = PyProject::load_or_discover(args.pyproject.as_deref())?;
+    let output = CommandOutput::from_quiet_and_verbose(args.quiet, args.verbose);
+    let venv = ensure_self_venv(output)?;
+    let ruff = venv.join(VENV_BIN).join("ruff");
+
+    let mut ruff_cmd = Command::new(ruff);
+    if env::var_os("RUFF_CACHE_DIR").is_none() {
+        ruff_cmd.env(
+            "RUFF_CACHE_DIR",
+            project.workspace_path().join(".ruff_cache"),
+        );
+    }
+    match output {
+        CommandOutput::Normal => {}
+        CommandOutput::Verbose => {
+            ruff_cmd.arg("--verbose");
+        }
+        CommandOutput::Quiet => {
+            ruff_cmd.arg("-q");
+        }
+    }
+    ruff_cmd.args(extra_args);
+    ruff_cmd.args(args.extra_args);
+
+    ruff_cmd.arg("--");
+    if args.paths.is_empty() {
+        let projects = locate_projects(project, args.all, &args.package[..])?;
+        for project in projects {
+            ruff_cmd.arg(project.root_path().as_os_str());
+        }
+    } else {
+        for file in args.paths {
+            ruff_cmd.arg(file.as_os_str());
+        }
+    }
+
+    let status = ruff_cmd.status()?;
+    if !status.success() {
+        let code = status.code().unwrap_or(1);
+        Err(QuietExit(code).into())
+    } else {
+        Ok(())
+    }
+}


### PR DESCRIPTION
`ruff` currently creates a `.ruff_cache` folder in whichever directory it's run from, causing many `.ruff_cache` folders throughout the worktree. Set it to a single fixed location, the workspace root.

