### PR TITLE
`rye tools list` show broken tools

### DIFF
--- a/rye/src/cli/tools.rs
+++ b/rye/src/cli/tools.rs
@@ -43,8 +43,12 @@ fn list_tools(cmd: ListCommand) -> Result<(), Error> {
     tools.sort();
 
     for (tool, mut info) in tools {
+        if !info.valid {
+            echo!("{} ({})", style(tool).red(), style("seems broken").red());
+            continue;
+        }
         if cmd.version_show {
-            echo!("{} {}", style(tool).cyan(), style(info.version).cyan());
+            echo!("{} ({})", style(tool).cyan(), info.version);
         } else {
             echo!("{}", style(tool).cyan());
         }

--- a/rye/src/installer.rs
+++ b/rye/src/installer.rs
@@ -72,11 +72,16 @@ static SUCCESSFULLY_DOWNLOADED_RE: Lazy<Regex> =
 pub struct ToolInfo {
     pub version: String,
     pub scripts: Vec<String>,
+    pub valid: bool,
 }
 
 impl ToolInfo {
-    pub fn new(version: String, scripts: Vec<String>) -> Self {
-        Self { version, scripts }
+    pub fn new(version: String, scripts: Vec<String>, valid: bool) -> Self {
+        Self {
+            version,
+            scripts,
+            valid,
+        }
     }
 }
 
@@ -347,17 +352,20 @@ pub fn list_installed_tools() -> Result<HashMap<String, ToolInfo>, Error> {
                 }
             }
         }
-        let tool_version = Command::new(target_venv_bin_path.join("python"))
+
+        let output = Command::new(target_venv_bin_path.join("python"))
             .arg("-c")
             .arg(TOOL_VERSION_SCRIPT)
             .arg(tool_name.clone())
             .stdout(Stdio::piped())
-            .output()?;
-        let tool_version = String::from_utf8_lossy(&tool_version.stdout)
-            .trim()
-            .to_string();
+            .output();
+        let valid = output.is_ok();
+        let tool_version = match output {
+            Ok(output) => String::from_utf8_lossy(&output.stdout).trim().to_string(),
+            Err(_) => String::new(),
+        };
 
-        rv.insert(tool_name, ToolInfo::new(tool_version, scripts));
+        rv.insert(tool_name, ToolInfo::new(tool_version, scripts, valid));
     }
 
     Ok(rv)


### PR DESCRIPTION
When a toolchain that various tools depend on is removed, it leads to those tools broken. Subsequently, the command `rye tools list` produces a vague error message: `error: No such file or directory (os error 2)`.

## Steps to reproduce

```sh
rye install art -p 3.11.4
rye toolchain remove 3.11.4
rye tools list
```

The output:
```sh
❯ rye tools list
error: No such file or directory (os error 2)
```

## After this PR
```sh
❯ rye tools list
art (seems broken)
```
