### PR TITLE
Fix `rye tools list` format issue introduced in #692

### DIFF
--- a/rye/src/cli/tools.rs
+++ b/rye/src/cli/tools.rs
@@ -44,11 +44,11 @@ fn list_tools(cmd: ListCommand) -> Result<(), Error> {
 
     for (tool, mut info) in tools {
         if !info.valid {
-            echo!("{} {}", style(tool).cyan(), style(info.version).cyan());
+            echo!("{} ({})", style(tool).red(), style("seems broken").red());
             continue;
         }
         if cmd.version_show {
-            echo!("{} ({})", style(tool).cyan(), info.version);
+            echo!("{} {}", style(tool).cyan(), style(info.version).cyan());
         } else {
             echo!("{}", style(tool).cyan());
         }


### PR DESCRIPTION
The last commit wrongly changed the format, restore it.