### PR TITLE
docs: clarify that `rye fetch/install/uninstall` are aliases

### DIFF
--- a/rye/src/cli/fetch.rs
+++ b/rye/src/cli/fetch.rs
@@ -8,12 +8,12 @@ use crate::pyproject::PyProject;
 use crate::sources::PythonVersionRequest;
 use crate::utils::CommandOutput;
 
-/// Fetches a Python interpreter for the local machine.
+/// Fetches a Python interpreter for the local machine. This is an alias of `rye toolchain fetch`.
 #[derive(Parser, Debug)]
 pub struct Args {
     /// The version of Python to fetch.
     ///
-    /// If no version is provided, the requested version will be fetched.
+    /// If no version is provided, the requested version from local project or `.python-version` will be fetched.
     version: Option<String>,
     /// Enables verbose diagnostics.
     #[arg(short, long)]

--- a/rye/src/cli/install.rs
+++ b/rye/src/cli/install.rs
@@ -10,7 +10,7 @@ use crate::installer::{install, resolve_local_requirement};
 use crate::sources::PythonVersionRequest;
 use crate::utils::CommandOutput;
 
-/// Installs a package as global tool.
+/// Installs a package as global tool. This is an alias of `rye tools install`.
 #[derive(Parser, Debug)]
 pub struct Args {
     /// The name of the package to install.

--- a/rye/src/cli/uninstall.rs
+++ b/rye/src/cli/uninstall.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 use crate::installer::uninstall;
 use crate::utils::CommandOutput;
 
-/// Uninstalls a global tool.
+/// Uninstalls a global tool. This is an alias of `rye tools uninstall`.
 #[derive(Parser, Debug)]
 pub struct Args {
     /// The package to uninstall


### PR DESCRIPTION
Multiple commands providing identical functionality can be a little confusing; clarify that some are simply aliases.