### PR TITLE
Remove redundant occurrences of "instead"

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -66,7 +66,7 @@ opt-out, or you run a custom shell you will need to do this manually.
     ```
 
     In some setups `.profile` is not sourced, in which case you can add it to your
-    `.bashrc` instead:
+    `.bashrc`:
 
     ```bash
     echo 'source "$HOME/.rye/env"' >> ~/.bashrc
@@ -81,7 +81,7 @@ opt-out, or you run a custom shell you will need to do this manually.
     ```
 
     In some setups `.profile` is not sourced, in which case you can add it to your
-    `.zprofile` instead:
+    `.zprofile`:
 
     ```bash
     echo 'source "$HOME/.rye/env"' >> ~/.zprofile
@@ -89,7 +89,7 @@ opt-out, or you run a custom shell you will need to do this manually.
 
 === "Fish"
 
-    Since fish does not support `env` files, you instead need to add
+    Since fish does not support `env` files, you need to add
     the shims directly.  This can be accomplished by running this
     command once:
 
@@ -99,7 +99,7 @@ opt-out, or you run a custom shell you will need to do this manually.
 
 === "Nushell"
 
-    Since nushell does not support `env` files, you instead need to add
+    Since nushell does not support `env` files, you need to add
     the shims directly.  This can be accomplished by adding this to your
     `env.nu` file:
 

--- a/docs/guide/pyproject.md
+++ b/docs/guide/pyproject.md
@@ -162,7 +162,7 @@ devserver = { cmd = "flask run --debug", env = { FLASK_APP = "./hello.py" } }
 
 This is a special key that can be set instead of `cmd` to make a command invoke multiple
 other commands.  Each command will be executed one after another.  If any of the commands
-fails the rest of the commands won't be executed and instead the chain fails.
+fails, the rest of the commands won't be executed and the chain fails.
 
 ```toml
 [tool.rye.scripts]

--- a/notes/metasrv.md
+++ b/notes/metasrv.md
@@ -18,7 +18,7 @@ If you have ever hit that URL you will have realized that it's an enormous HTML 
 package very uploaded to PyPI.  Yet this is still in some sense the canonical way to install
 packages.  If you for instance use `Rye` today you configure the index by pointing to that URL.
 
-With the use of a **meta server**, one would instead point it to a meta server instead.  So for instance
+With the use of a **meta server**, one would instead point it to a meta server.  So for instance
 the meta server for `pypi.org` could be hosted at a different URL, say `https://meta.pypi.org/`.
 That meta server URL fully replaces the existing index URL.  Each meta server is supposed to target
 a single index only.  A package manager _only_ interfaces with the meta server and it's the meta

--- a/rye/src/cli/mod.rs
+++ b/rye/src/cli/mod.rs
@@ -132,7 +132,7 @@ pub fn execute() -> Result<(), Error> {
         Command::List(cmd) => list::execute(cmd),
         Command::Shell(..) => {
             bail!(
-                "unknown command. The shell command was removed. Activate the virtualenv instead with '{}' instead.",
+                "unknown command. The shell command was removed. Activate the virtualenv with '{}' instead.",
                 if cfg!(windows) {
                     ".venv\\Scripts\\activate"
                 } else {


### PR DESCRIPTION
I initially noted "instead" twice in an error message, and then went on to look for more occurrences of the word that could be removed to make things a bit easier to read while stil clear.