### PR TITLE
find-downloads: prefer `pgo` over `lto` builds

### DIFF
--- a/rye-devtools/src/rye_devtools/find_downloads.py
+++ b/rye-devtools/src/rye_devtools/find_downloads.py
@@ -122,8 +122,8 @@ class CPythonFinder(Finder):
         "shared-noopt",
         "shared-noopt",
         "pgo+lto",
-        "lto",
         "pgo",
+        "lto",
     ]
     HIDDEN_FLAVORS = [
         "debug",


### PR DESCRIPTION
From the [python-build-standalone doc](https://gregoryszorc.com/docs/python-build-standalone/main/distributions.html#install-only-archive)

> Builds are generally preferred in the following order: pgo+lto, pgo, lto, noopt.