### PR TITLE
Add hello function's type hint to pass mypy --strict

### DIFF
--- a/rye/src/cli/init.rs
+++ b/rye/src/cli/init.rs
@@ -188,7 +188,7 @@ const LICENSE_TEMPLATE: &str = r#"
 "#;
 
 /// Template for the __init__.py
-const INIT_PY_TEMPLATE: &str = r#"def hello():
+const INIT_PY_TEMPLATE: &str = r#"def hello() -> str:
     return "Hello from {{ name }}!"
 
 "#;


### PR DESCRIPTION
Many thanks to create and develop rye.

I am sending a small tweak proposal to help many rye users save the effort of writing type hints in the hello function of `__init__.py`.

```
% rye --version
rye 0.23.0
commit: 0.23.0 (0fdcdda6c 2024-02-13)
platform: macos (aarch64)
self-python: cpython@3.12
symlink support: true

% rye init example
% cd example
% rye add mypy --dev  # mypy-1.8.0 installed
% rye sync

% rye run mypy --strict .
src/example/__init__.py:1: error: Function is missing a return type annotation  [no-untyped-def]
Found 1 error in 1 file (checked 1 source file)

% vim src/example/__init__.py
% cat src/example/__init__.py
def hello() -> str:
    return "Hello from example!"
% rye run mypy --strict .
Success: no issues found in 1 source file
```