### PR TITLE
Use `fs_err` for better file operation error message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1848,6 +1848,7 @@ dependencies = [
  "decompress",
  "dialoguer",
  "flate2",
+ "fs-err",
  "fslock",
  "git-testament",
  "globset",

--- a/rye/Cargo.toml
+++ b/rye/Cargo.toml
@@ -60,6 +60,7 @@ python-pkginfo = { version = "0.6.0", features = ["serde"] }
 sysinfo = { version = "0.29.4", default-features = false, features = [] }
 home = "0.5.9"
 ctrlc = "3.4.2"
+fs-err = "2.11.0"
 
 [target."cfg(unix)".dependencies]
 whattheshell = "1.0.1"

--- a/rye/src/bootstrap.rs
+++ b/rye/src/bootstrap.rs
@@ -1,10 +1,11 @@
+use fs_err as fs;
 use std::borrow::Cow;
+use std::env;
 use std::env::consts::EXE_EXTENSION;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::atomic::{self, AtomicBool};
-use std::{env, fs};
 
 use anyhow::{anyhow, bail, Context, Error};
 use console::style;

--- a/rye/src/cli/build.rs
+++ b/rye/src/cli/build.rs
@@ -1,4 +1,4 @@
-use std::fs;
+use fs_err as fs;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 

--- a/rye/src/cli/config.rs
+++ b/rye/src/cli/config.rs
@@ -60,6 +60,7 @@ pub struct ActionArgs {
     #[arg(long)]
     unset: Vec<String>,
 }
+
 pub fn execute(cmd: Args) -> Result<(), Error> {
     let mut config = Config::current();
     let doc = Arc::make_mut(&mut config).doc_mut();

--- a/rye/src/cli/init.rs
+++ b/rye/src/cli/init.rs
@@ -1,8 +1,9 @@
+use fs_err as fs;
 use std::collections::BTreeMap;
+use std::env;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::str::FromStr;
-use std::{env, fs};
 
 use anyhow::{anyhow, bail, Context, Error};
 use clap::Parser;

--- a/rye/src/cli/pin.rs
+++ b/rye/src/cli/pin.rs
@@ -1,5 +1,5 @@
+use fs_err as fs;
 use std::env;
-use std::fs;
 use std::path::PathBuf;
 
 use anyhow::Context;

--- a/rye/src/cli/rye.rs
+++ b/rye/src/cli/rye.rs
@@ -1,10 +1,11 @@
+use fs_err as fs;
 use std::borrow::Cow;
+use std::env;
 use std::env::consts::{ARCH, EXE_EXTENSION, OS};
 use std::env::{join_paths, split_paths};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::Arc;
-use std::{env, fs};
 
 use anyhow::{anyhow, bail, Context, Error};
 use clap::{CommandFactory, Parser};

--- a/rye/src/cli/toolchain.rs
+++ b/rye/src/cli/toolchain.rs
@@ -1,7 +1,7 @@
+use fs_err as fs;
 use std::cmp::Reverse;
 use std::collections::HashMap;
 use std::env::consts::{ARCH, OS};
-use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 

--- a/rye/src/config.rs
+++ b/rye/src/config.rs
@@ -1,4 +1,4 @@
-use std::fs;
+use fs_err as fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 

--- a/rye/src/installer.rs
+++ b/rye/src/installer.rs
@@ -1,7 +1,8 @@
+use fs_err as fs;
 use std::collections::{BTreeMap, HashMap};
+use std::env;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::{env, fs};
 
 use anyhow::{bail, Context, Error};
 use console::style;

--- a/rye/src/lock.rs
+++ b/rye/src/lock.rs
@@ -258,7 +258,7 @@ fn find_exclusions(projects: &[PyProject]) -> Result<HashSet<Requirement>, Error
                 if name == "PROJECT_ROOT" {
                     Some(project.workspace_path().to_string_lossy().to_string())
                 } else {
-                    std::env::var(name).ok()
+                    env::var(name).ok()
                 }
             })?);
         }
@@ -463,7 +463,7 @@ fn finalize_lockfile(
     sources: &ExpandedSources,
     lock_options: &LockOptions,
 ) -> Result<(), Error> {
-    let mut rv = BufWriter::new(fs::File::create(out)?);
+    let mut rv = BufWriter::new(fs_err::File::create(out)?);
     lock_options.write_header(&mut rv)?;
 
     // only if we are asked to include sources we do that.
@@ -472,7 +472,7 @@ fn finalize_lockfile(
         writeln!(rv)?;
     }
 
-    for line in fs::read_to_string(generated)?.lines() {
+    for line in fs_err::read_to_string(generated)?.lines() {
         // we deal with this explicitly.
         if line.trim().is_empty()
             || line.starts_with("--index-url ")

--- a/rye/src/piptools.rs
+++ b/rye/src/piptools.rs
@@ -1,4 +1,4 @@
-use std::fs;
+use fs_err as fs;
 use std::path::PathBuf;
 use std::process::Command;
 

--- a/rye/src/platform.rs
+++ b/rye/src/platform.rs
@@ -1,7 +1,8 @@
+use fs_err as fs;
+use std::env;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::Mutex;
-use std::{env, fs};
 
 use anyhow::{anyhow, Context, Error};
 
@@ -264,7 +265,7 @@ pub fn get_credentials() -> Result<toml_edit::Document, Error> {
 }
 
 pub fn write_credentials(doc: &toml_edit::Document) -> Result<(), Error> {
-    std::fs::write(get_credentials_filepath()?, doc.to_string())
+    fs::write(get_credentials_filepath()?, doc.to_string())
         .context("unable to write to the credentials file")
 }
 

--- a/rye/src/pyproject.rs
+++ b/rye/src/pyproject.rs
@@ -1,11 +1,11 @@
 use clap::ValueEnum;
 use core::fmt;
+use fs_err as fs;
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::env;
 use std::ffi::OsStr;
 use std::ffi::OsString;
-use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::str::FromStr;

--- a/rye/src/sync.rs
+++ b/rye/src/sync.rs
@@ -1,6 +1,7 @@
+use fs_err as fs;
+use std::env;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::{env, fs};
 
 use anyhow::{bail, Context, Error};
 use console::style;

--- a/rye/src/utils/mod.rs
+++ b/rye/src/utils/mod.rs
@@ -1,9 +1,10 @@
+use fs_err as fs;
 use std::borrow::Cow;
 use std::convert::Infallible;
+use std::fmt;
 use std::io::{Cursor, Read};
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus, Stdio};
-use std::{fmt, fs};
 
 use anyhow::{anyhow, bail, Error};
 use dialoguer::theme::{ColorfulTheme, Theme};
@@ -281,7 +282,7 @@ pub fn unpack_archive(contents: &[u8], dst: &Path, strip_components: usize) -> R
                 {
                     use std::os::unix::fs::PermissionsExt;
                     if let Some(mode) = file.unix_mode() {
-                        fs::set_permissions(&path, fs::Permissions::from_mode(mode))?;
+                        fs::set_permissions(&path, std::fs::Permissions::from_mode(mode))?;
                     }
                 }
             }

--- a/rye/src/utils/unix.rs
+++ b/rye/src/utils/unix.rs
@@ -1,7 +1,7 @@
-use std::path::{Path, PathBuf};
-use std::{env, fs};
-
 use anyhow::{Context, Error};
+use fs_err as fs;
+use std::env;
+use std::path::{Path, PathBuf};
 
 pub(crate) fn add_to_path(rye_home: &Path) -> Result<(), Error> {
     // for regular shells just add the path to `.profile`


### PR DESCRIPTION
[fs_err](https://crates.io/crates/fs-err) is drop-in replacement for `std::fs`, that provides more helpful messages on errors.

Take #727 as an exmaple,

before:
```
error: No such file or directory (os error 2)
```

after:
```
error: failed to create file `/tmp/rye/config.toml`

Caused by:
    No such file or directory (os error 2)
```