### PR TITLE
--script and --lib flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ that were not yet released.
 
 _Unreleased_
 
+- `init` now supports `--script` and `--lib` to generate a script or library project.  #738
+
 - Fixed `rye config --show-path` abort with an error. #706
 
 - Bumped `uv` to 0.1.7.  #719, #740

--- a/docs/guide/basics.md
+++ b/docs/guide/basics.md
@@ -136,3 +136,38 @@ virtualenv is located and more.
 ```
 rye show
 ```
+
+## Executable projects
+
+To generate a project that is aimed to provide an executable
+script, use `rye init --script`:
+
+```shell
+rye init --script my-project
+cd my-project
+```
+
+The following structure will be created:
+
+```
+.
+├── .git
+├── .gitignore
+├── .python-version
+├── README.md
+├── pyproject.toml
+└── src
+    └── my_project
+        └── __init__.py
+        └── __main__.py
+```
+
+The [`pyproject.toml`](pyproject.md) will be generated with a
+[`[project.scripts]`](pyproject.md#projectscripts) section named `hello`
+that points to the `main()` function of `__init__.py`. After you
+synchronized your changes, you can run the script with `rye run my-project`.
+
+```shell
+rye sync
+rye run hello
+```

--- a/rye/src/templates/LICENSE.txt.j2
+++ b/rye/src/templates/LICENSE.txt.j2
@@ -1,0 +1,1 @@
+{{ license_text }}

--- a/rye/src/templates/README.md.j2
+++ b/rye/src/templates/README.md.j2
@@ -1,0 +1,7 @@
+# {{ name }}
+
+Describe your project here.
+
+{%- if license %}
+* License: {{ license }}
+{%- endif %}

--- a/rye/src/templates/gitignore.j2
+++ b/rye/src/templates/gitignore.j2
@@ -1,0 +1,15 @@
+# python generated files
+__pycache__/
+*.py[oc]
+build/
+dist/
+wheels/
+*.egg-info
+
+{%- if is_rust %}
+# Rust
+target/
+{%- endif %}
+
+# venv
+.venv

--- a/rye/src/templates/lib/default/__init__.py.j2
+++ b/rye/src/templates/lib/default/__init__.py.j2
@@ -1,0 +1,2 @@
+def hello() -> str:
+    return "Hello from {{ name }}!"

--- a/rye/src/templates/lib/maturin/Cargo.toml.j2
+++ b/rye/src/templates/lib/maturin/Cargo.toml.j2
@@ -1,0 +1,12 @@
+[package]
+name = {{ name }}
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+name = {{ name_safe }}
+crate-type = ["cdylib"]
+
+[dependencies]
+pyo3 = "0.19.0"

--- a/rye/src/templates/lib/maturin/__init__.py.j2
+++ b/rye/src/templates/lib/maturin/__init__.py.j2
@@ -1,0 +1,3 @@
+from {{ name_safe }}._lowlevel import hello
+
+__all__ = ["hello"]

--- a/rye/src/templates/lib/maturin/lib.rs.j2
+++ b/rye/src/templates/lib/maturin/lib.rs.j2
@@ -1,0 +1,14 @@
+const LIB_RS_TEMPLATE: &str = r#"use pyo3::prelude::*;
+
+/// Prints a message.
+#[pyfunction]
+fn hello() -> PyResult<String> {
+    Ok("Hello from {{ name }}!".into())
+}
+
+/// A Python module implemented in Rust.
+#[pymodule]
+fn _lowlevel(_py: Python, m: &PyModule) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(hello, m)?)?;
+    Ok(())
+}

--- a/rye/src/templates/pyproject.toml.j2
+++ b/rye/src/templates/pyproject.toml.j2
@@ -1,0 +1,86 @@
+[project]
+name = {{ name }}
+version = {{ version }}
+description = {{ description }}
+{%- if author %}
+authors = [
+    { name = {{ author[0] }}, email = {{ author[1] }} }
+]
+{%- endif %}
+{%- if dependencies %}
+dependencies = [
+{%- for dependency in dependencies %}
+    {{ dependency }},
+{%- endfor %}
+]
+{%- else %}
+dependencies = []
+{%- endif %}
+{%- if with_readme %}
+readme = "README.md"
+{%- endif %}
+requires-python = {{ requires_python }}
+{%- if license %}
+license = { text = {{ license }} }
+{%- endif %}
+{%- if private %}
+classifiers = ["Private :: Do Not Upload"]
+{%- endif %}
+{%- if is_script %}
+
+[project.scripts]
+hello = {{ name_safe ~ ":main"}}
+{%- endif %}
+
+{%- if not is_virtual %}
+
+[build-system]
+{%- if build_system == "hatchling" %}
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+{%- elif build_system == "setuptools" %}
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+{%- elif build_system == "flit" %}
+requires = ["flit_core>=3.4"]
+build-backend = "flit_core.buildapi"
+{%- elif build_system == "pdm" %}
+requires = ["pdm-backend"]
+build-backend = "pdm.backend"
+{%- elif build_system == "maturin" %}
+requires = ["maturin>=1.2,<2.0"]
+build-backend = "maturin"
+{%- endif %}
+{%- endif %}
+
+[tool.rye]
+managed = true
+{%- if is_virtual %}
+virtual = true
+{%- endif %}
+{%- if dev_dependencies %}
+dev-dependencies = [
+{%- for dependency in dev_dependencies %}
+    {{ dependency }},
+{%- endfor %}
+]
+{%- else %}
+dev-dependencies = []
+{%- endif %}
+
+{%- if not is_virtual %}
+{%- if build_system == "hatchling" %}
+
+[tool.hatch.metadata]
+allow-direct-references = true
+
+[tool.hatch.build.targets.wheel]
+packages = [{{ "src/" ~ name_safe }}]
+{%- elif build_system == "maturin" %}
+
+[tool.maturin]
+python-source = "python"
+module-name = {{ name_safe ~ "._lowlevel" }}
+features = ["pyo3/extension-module"]
+{%- endif %}
+{%- endif %}

--- a/rye/src/templates/script/default/__init__.py.j2
+++ b/rye/src/templates/script/default/__init__.py.j2
@@ -1,0 +1,3 @@
+def main() -> int:
+    print("Hello from {{ name }}!")
+    return 0

--- a/rye/src/templates/script/default/__main__.py.j2
+++ b/rye/src/templates/script/default/__main__.py.j2
@@ -1,0 +1,4 @@
+import {{ name_safe }}
+import sys
+
+sys.exit({{ name_safe }}.main())

--- a/rye/src/templates/setuptools.py.j2
+++ b/rye/src/templates/setuptools.py.j2
@@ -1,0 +1,15 @@
+import json, sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+def setup(**kwargs) -> None:
+    print(json.dumps(kwargs), file=sys.stderr)
+
+if __name__ == "setuptools":
+    _setup_proxy_module = sys.modules.pop("setuptools")
+    _setup_proxy_cwd = sys.path.pop(0)
+    import setuptools as __setuptools
+    sys.path.insert(0, _setup_proxy_cwd)
+    sys.modules["setuptools"] = _setup_proxy_module
+    def __getattr__(name):
+        return getattr(__setuptools, name)

--- a/rye/tests/common/mod.rs
+++ b/rye/tests/common/mod.rs
@@ -152,6 +152,12 @@ impl Space {
     }
 
     #[allow(unused)]
+    pub fn read_toml<P: AsRef<Path>>(&self, path: P) -> toml_edit::Document {
+        let p = self.project_path().join(path.as_ref());
+        std::fs::read_to_string(&p).unwrap().parse().unwrap()
+    }
+
+    #[allow(unused)]
     pub fn write<P: AsRef<Path>, B: AsRef<[u8]>>(&self, path: P, contents: B) {
         let p = self.project_path().join(path.as_ref());
         fs::create_dir_all(p.parent().unwrap()).ok();

--- a/rye/tests/test_init.rs
+++ b/rye/tests/test_init.rs
@@ -1,0 +1,183 @@
+use crate::common::{get_bin, rye_cmd_snapshot, Space};
+
+mod common;
+
+// Test that init --lib works
+#[test]
+fn test_init_lib() {
+    let space = Space::new();
+    space
+        .cmd(get_bin())
+        .arg("init")
+        .arg("--name")
+        .arg("my-project")
+        .arg("-q")
+        .arg("--lib")
+        .current_dir(space.project_path())
+        .status()
+        .expect("initialization successful");
+
+    rye_cmd_snapshot!(space.rye_cmd().arg("sync"), @r###"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+        Initializing new virtualenv in [TEMP_PATH]/project/.venv
+        Python version: cpython@3.12.1
+        Generating production lockfile: [TEMP_PATH]/project/requirements.lock
+        Generating dev lockfile: [TEMP_PATH]/project/requirements-dev.lock
+        Installing dependencies
+        Done!
+
+        ----- stderr -----
+        warning: Requirements file [TEMP_FILE] does not contain any dependencies
+        Built 1 editable in [EXECUTION_TIME]
+        Resolved 1 package in [EXECUTION_TIME]
+        warning: Requirements file [TEMP_FILE] does not contain any dependencies
+        Built 1 editable in [EXECUTION_TIME]
+        Resolved 1 package in [EXECUTION_TIME]
+        Built 1 editable in [EXECUTION_TIME]
+        Installed 1 package in [EXECUTION_TIME]
+         + my-project==0.1.0 (from file:[TEMP_PATH]/project)
+    "###);
+
+    rye_cmd_snapshot!(space.rye_cmd().arg("run").arg("python").arg("-c").arg("import my_project; print(my_project.hello())"), @r###"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+        Hello from my-project!
+
+        ----- stderr -----
+    "###);
+
+    assert!(
+        space.read_toml("pyproject.toml")["project"]
+            .get("scripts")
+            .is_none(),
+        "[project.scripts] should not be present"
+    )
+}
+
+// The default is the same as --lib
+#[test]
+fn test_init_default() {
+    let space = Space::new();
+    space
+        .cmd(get_bin())
+        .arg("init")
+        .arg("--name")
+        .arg("my-project")
+        .arg("-q")
+        .current_dir(space.project_path())
+        .status()
+        .expect("initialization successful");
+
+    rye_cmd_snapshot!(space.rye_cmd().arg("sync"), @r###"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+        Initializing new virtualenv in [TEMP_PATH]/project/.venv
+        Python version: cpython@3.12.1
+        Generating production lockfile: [TEMP_PATH]/project/requirements.lock
+        Generating dev lockfile: [TEMP_PATH]/project/requirements-dev.lock
+        Installing dependencies
+        Done!
+
+        ----- stderr -----
+        warning: Requirements file [TEMP_FILE] does not contain any dependencies
+        Built 1 editable in [EXECUTION_TIME]
+        Resolved 1 package in [EXECUTION_TIME]
+        warning: Requirements file [TEMP_FILE] does not contain any dependencies
+        Built 1 editable in [EXECUTION_TIME]
+        Resolved 1 package in [EXECUTION_TIME]
+        Built 1 editable in [EXECUTION_TIME]
+        Installed 1 package in [EXECUTION_TIME]
+         + my-project==0.1.0 (from file:[TEMP_PATH]/project)
+    "###);
+
+    rye_cmd_snapshot!(space.rye_cmd().arg("run").arg("python").arg("-c").arg("import my_project; print(my_project.hello())"), @r###"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+        Hello from my-project!
+
+        ----- stderr -----
+    "###);
+
+    assert!(
+        space.read_toml("pyproject.toml")["project"]
+            .get("scripts")
+            .is_none(),
+        "[project.scripts] should not be present"
+    )
+}
+
+// Test that init --script works
+#[test]
+fn test_init_script() {
+    let space = Space::new();
+    space
+        .cmd(get_bin())
+        .arg("init")
+        .arg("--name")
+        .arg("my-project")
+        .arg("-q")
+        .arg("--script")
+        .current_dir(space.project_path())
+        .status()
+        .expect("initialization successful");
+
+    rye_cmd_snapshot!(space.rye_cmd().arg("sync"), @r###"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+        Initializing new virtualenv in [TEMP_PATH]/project/.venv
+        Python version: cpython@3.12.1
+        Generating production lockfile: [TEMP_PATH]/project/requirements.lock
+        Generating dev lockfile: [TEMP_PATH]/project/requirements-dev.lock
+        Installing dependencies
+        Done!
+
+        ----- stderr -----
+        warning: Requirements file [TEMP_FILE] does not contain any dependencies
+        Built 1 editable in [EXECUTION_TIME]
+        Resolved 1 package in [EXECUTION_TIME]
+        warning: Requirements file [TEMP_FILE] does not contain any dependencies
+        Built 1 editable in [EXECUTION_TIME]
+        Resolved 1 package in [EXECUTION_TIME]
+        Built 1 editable in [EXECUTION_TIME]
+        Installed 1 package in [EXECUTION_TIME]
+         + my-project==0.1.0 (from file:[TEMP_PATH]/project)
+    "###);
+
+    rye_cmd_snapshot!(space.rye_cmd().arg("run").arg("hello"), @r###"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+        Hello from my-project!
+
+        ----- stderr -----
+    "###);
+
+    rye_cmd_snapshot!(space.rye_cmd().arg("run").arg("python").arg("-mmy_project"), @r###"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+        Hello from my-project!
+
+        ----- stderr -----
+    "###);
+}
+
+// Test that init --script and --lib are incompatible.
+#[test]
+fn test_init_lib_and_script_incompatible() {
+    let space = Space::new();
+    rye_cmd_snapshot!(space.cmd(get_bin()).arg("init").arg("--name").arg("my-project").arg("--script").arg("--lib").current_dir(space.project_path()), @r###"
+        success: false
+        exit_code: 2
+        ----- stdout -----
+
+        ----- stderr -----
+        error: an argument cannot be used with one or more of the other specified arguments
+    "###);
+}


### PR DESCRIPTION
- **fix missing space in init --build-system flag description**
  

- **init: add support for --bin**
   --lib and --lib-rs,This adds support for three new flags which determine the templates
  we generate:
  
 1. We adding --lib, which will generate the standard python library
       We no longer generate `[project.scripts]` section and updated
       the template.
2. We added --script, which will generate a package with a __main__.py,
       __init__.py and an entry to `[project.scripts]`. `__main__.py` follows
       semantics found in Python packages such as `ensurepip` and `pip.
3. We added simple tests. Tests do not cover yet `--lib` and `--build-system=maturin`.
4. We added a short section about executable projects to docs/guide/basic.md
5. We moved all in init.rs to a `templates` folder and use `include_str!()`.