### PR TITLE
Better shell detection for fish and zsh during installation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,25 +403,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1657,26 +1638,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rayon"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1882,7 +1843,6 @@ dependencies = [
  "toml_edit",
  "url",
  "walkdir",
- "whattheshell",
  "which",
  "winapi",
  "winreg",
@@ -2152,7 +2112,6 @@ dependencies = [
  "libc",
  "ntapi",
  "once_cell",
- "rayon",
  "winapi",
 ]
 
@@ -2564,16 +2523,6 @@ name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
-
-[[package]]
-name = "whattheshell"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c94d2698698cb1322e20292460fd158373af5fb2802afb6bea9ee17628efddb"
-dependencies = [
- "sysinfo",
- "thiserror",
-]
 
 [[package]]
 name = "which"

--- a/rye/Cargo.toml
+++ b/rye/Cargo.toml
@@ -62,7 +62,6 @@ home = "0.5.9"
 ctrlc = "3.4.2"
 
 [target."cfg(unix)".dependencies]
-whattheshell = "1.0.1"
 xattr = "1.3.1"
 
 [target."cfg(windows)".dependencies]

--- a/rye/src/cli/rye.rs
+++ b/rye/src/cli/rye.rs
@@ -388,9 +388,9 @@ fn uninstall(args: UninstallCommand) -> Result<(), Error> {
 }
 
 #[cfg(unix)]
-fn is_fish() -> bool {
-    use whattheshell::Shell;
-    Shell::infer().map_or(false, |x| matches!(x, Shell::Fish))
+fn has_fish() -> bool {
+    use which::which;
+    which("fish").is_ok()
 }
 
 #[cfg(unix)]
@@ -677,8 +677,8 @@ fn add_rye_to_path(mode: &InstallMode, shims: &Path, ask: bool) -> Result<(), Er
                 echo!();
                 echo!("    source \"{}/env\"", rye_home.display());
                 echo!();
-            }s
-            if is_fish() {
+            }
+            if has_fish() {
                 echo!("To make it work with fish, run this once instead:");
                 echo!();
                 echo!(

--- a/rye/src/cli/rye.rs
+++ b/rye/src/cli/rye.rs
@@ -393,6 +393,12 @@ fn is_fish() -> bool {
     Shell::infer().map_or(false, |x| matches!(x, Shell::Fish))
 }
 
+#[cfg(unix)]
+fn has_zsh() -> bool {
+    use which::which;
+    which("zsh").is_ok()
+}
+
 fn perform_install(
     mode: InstallMode,
     toolchain_path: Option<&Path>,
@@ -666,6 +672,12 @@ fn add_rye_to_path(mode: &InstallMode, shims: &Path, ask: bool) -> Result<(), Er
             echo!();
             echo!("    source \"{}/env\"", rye_home.display());
             echo!();
+            if has_zsh() {
+                echo!("To make it work with zsh, you might need to add this to your .zprofile:");
+                echo!();
+                echo!("    source \"{}/env\"", rye_home.display());
+                echo!();
+            }s
             if is_fish() {
                 echo!("To make it work with fish, run this once instead:");
                 echo!();


### PR DESCRIPTION
As discussed in [here](https://github.com/mitsuhiko/rye/pull/731#discussion_r1500264325), shell detection based on the current shell with `whattheshell` does not work with the suggested installation method via the `get.sh` script, since the detected shell will be the one used to run `get.sh`. Therefore, even if the used shell is `fish` or `zsh`, running ` curl https://rye-up.com/get | bash` will not print the note for the fish shell because `bash` will be detected.

The same issue prevents from conditonally adding rye to `.zprofile` for zsh.

This PR changes the shell detection to use `which` to detect if fish or zsh is installed on the system. It further adds a note on how to use rye with zsh.

Closes #728 